### PR TITLE
templates/query.html Fix typo in placeholder text

### DIFF
--- a/puppetboard/templates/query.html
+++ b/puppetboard/templates/query.html
@@ -23,7 +23,7 @@
         <div class="control-group {% if form.query.errors %} error {% endif %}">
           {{form.query.label(class_="control-label")}}
           <div class="controls">
-            {{form.query(class_="input-block-level", autofocus="autofocus", rows=5, placeholder="\"=\", \"name\" \"hostname\"")}}
+            {{form.query(class_="input-block-level", autofocus="autofocus", rows=5, placeholder="\"=\", \"name\", \"hostname\"")}}
             {% if form.query.errors %}
             <span class="help-inline">{% for error in form.query.errors %}{{error}}{% endfor %}</span>
             {% endif %}


### PR DESCRIPTION
The placeholder text on the query form wasn't correct syntax.
