### PR TITLE
make failed/success event counts clickable

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from flask import (
     Flask, render_template, abort, url_for,
     Response, stream_with_context, redirect,
+    request
     )
 
 from pypuppetdb import connect
@@ -147,6 +148,7 @@ def nodes():
     works. Once pagination is in place we can change this but we'll need to
     provide a search feature instead.
     """
+    status_arg = request.args.get('status', '')
     latest_events = puppetdb._query(
         'event-counts',
         query='["=", "latest-report?", true]',
@@ -161,8 +163,12 @@ def nodes():
         if status:
             node.status = status[0]
         else:
-            node.status = None
-        nodes.append(node)
+            node.status = {}
+        if status_arg:
+            if node.status.has_key(status_arg) and node.status[status_arg]:
+                nodes.append(node)
+        else:
+            nodes.append(node)
 
     return Response(stream_with_context(
         stream_template('nodes.html', nodes=nodes)))

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -4,11 +4,15 @@
   <div class="row">
     <div class="span12">
       <div class="span4 stat">
-        <h1 class="error">{{latest_event_count['failures']}} <small>node(s)</small></h1>
-        <span>with failures in latest reports</span>
+       <a href="nodes?status=failures">
+         <h1 class="error">{{latest_event_count['failures']}} <small>node(s)</small></h1>
+       </a>
+       <span>with failures in latest reports</span>
       </div>
       <div class="span4 stat">
-        <h1 class="success">{{latest_event_count['successes']}} <small>node(s)</small></h1>
+        <a href="nodes?status=successes">
+          <h1 class="success">{{latest_event_count['successes']}} <small>node(s)</small></h1>
+        </a>
         <span>with successes in latest reports</span>
       </div>
       <div class="span4 stat">


### PR DESCRIPTION
This PR will make the failed/success event count clickable in Overview. This for easy and fast access to those nodes.
