### PR TITLE
Fix for latest report if there is no report available

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -205,13 +205,13 @@ def report_latest(node_name):
     """
     node = get_or_abort(puppetdb.node, node_name)
     reports = get_or_abort(puppetdb._query, 'reports',
-                           query='["=","certname","' + node_name + '"]',
+                           query='["=","certname","{0}"]'.format(node_name),
                            limit=1)
     if len(reports) > 0:
         report = reports[0]['hash']
         return redirect(url_for('report', node=node_name, report_id=report))
     else:
-        abort(500)
+        abort(404)
 
 
 @app.route('/report/<node>/<report_id>')

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -99,3 +99,6 @@ div[id^='message-event'] {
   background-color: rgb(231, 76, 60);
   background-color: rgb(129, 145, 146);
 }
+.btn-lastreport {
+  width:100px;
+}

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -80,9 +80,9 @@
               <td><a href="{{url_for('node', node_name=node.name)}}">{{ node.name }}</a></td>
               <td>
                 {% if node.unreported_time != None or node.status != 'unreported' %}
-                  <a class="btn btn-small btn-primary" href="{{url_for('report_latest', node_name=node.name)}}">Latest Report</a>
+                  <a class="btn btn-small btn-primary btn-lastreport" href="{{url_for('report_latest', node_name=node.name)}}">Latest Report</a>
                 {% else %}
-                  <a class="btn btn-small"> No Report </a>
+                  <a class="btn btn-small btn-lastreport"> No Report </a>
                 {% endif %}
               </td>
             </tr>


### PR DESCRIPTION
- report/latest/<node_name> uses limit parameter in _query
  to get just one report
- disable "Latest Report" button if there is no report
- HTTP Status 500 if there is no report on report/latest/<node_name>
