### PR TITLE
Adding link to node details page when viewing a specific report

### DIFF
--- a/puppetboard/templates/report.html
+++ b/puppetboard/templates/report.html
@@ -12,7 +12,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>{{report.node}}</td>
+      <td><a href="{{url_for('node', node_name=report.node)}}">{{ report.node }}</a></td>
       <td>
         {{report.version}}
       </td>


### PR DESCRIPTION
When looking at a specific report, it would be good to link back to the node for more detailed information. Right now, you have to manually change the url, navigate through nodes and filter or go to overview page and find it there.
