### PR TITLE
Report rounded avg. resources per node.

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -100,7 +100,7 @@ def index():
     metrics = {
         'num_nodes': num_nodes['Value'],
         'num_resources': num_resources['Value'],
-        'avg_resources_node': "{0:10.6f}".format(avg_resources_node['Value']),
+        'avg_resources_node': "{0:10.0f}".format(avg_resources_node['Value']),
         }
 
     nodes = puppetdb.nodes(


### PR DESCRIPTION
I was wondering what the purpose is of this metric?
Having puppetboard report that my nodes have 64.612387 resources on average doesn't seem all that useful as I cannot apply the .612387 part of a resource.
So perhaps this average should yield full (rounded) resources instead?
