### PR TITLE
Use config from settings.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# PuppetDB Settings
+/settings.py

--- a/README.rst
+++ b/README.rst
@@ -133,8 +133,10 @@ You can run it in development mode by simply executing:
    $ python dev.py
 
 Use ``PUPPETBOARD_SETTINGS`` to change the different settings or patch
-``default_settings.py`` directly. Take care not to include your local
-changes on that file when submitting patches for Puppetboard.
+``default_settings.py`` directly. Take care not to include your local changes on
+that file when submitting patches for Puppetboard. Place a settings.py file
+inside the base directory of the git repository that will be used, if the
+environment variable is not set.
 
 Production
 ----------

--- a/dev.py
+++ b/dev.py
@@ -1,5 +1,11 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
+import os
+
+if 'PUPPETBOARD_SETTINGS' not in os.environ:
+    os.environ['PUPPETBOARD_SETTINGS'] = os.path.join(
+        os.getcwd(), 'settings.py'
+    )
 
 from puppetboard.app import app
 from puppetboard.default_settings import DEV_LISTEN_HOST, DEV_LISTEN_PORT


### PR DESCRIPTION
This enables to use a settings.py in the base directory of the repo,
if no environment variable set.
