### PR TITLE
Include fonts in MANIFEST for offline mode

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.rst
 include CHANGELOG.rst
 include LICENSE
-recursive-include puppetboard/static *.css *.js
+recursive-include puppetboard/static *.css *.js *icons.* Open_Sans.woff
 recursive-include puppetboard/templates *.html


### PR DESCRIPTION
The static fonts were all missing when installed via pip and running in
OFFLINE_MODE. Update pip manifest to grab the fonts, too.
