### PR TITLE
Update requests -> v 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ WTForms==1.0.5
 Werkzeug==0.9.4
 itsdangerous==0.23
 pypuppetdb==0.1.1
-requests==2.2.1
+requests==2.7.0


### PR DESCRIPTION
Upgrade of request package is needed because we can't install puppetboard on debian jessie with puppet module without a newer version.

Error was :
``` AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'```