### PR TITLE
Include report status and logs

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -130,6 +130,7 @@ def index():
         'noop': 0
         }
 
+    report_status = {}
     for node in nodes:
         if node.status == 'unreported':
             stats['unreported'] += 1
@@ -141,15 +142,21 @@ def index():
             stats['noop'] += 1
         else:
             stats['unchanged'] += 1
+        reports = get_or_abort(puppetdb._query, 'reports',
+                               query='["=","certname","{0}"]'.format(node.name),
+                               limit=1)
+        if len(reports) > 0:
+            report_status[node.name] = reports[0]['status']
 
-        if node.status != 'unchanged':
+        if node.status != 'unchanged' or report_status[node.name] == 'failed':
             nodes_overview.append(node)
 
     return render_template(
         'index.html',
         metrics=metrics,
         nodes=nodes_overview,
-        stats=stats
+        stats=stats,
+        report_status=report_status
         )
 
 
@@ -169,14 +176,20 @@ def nodes():
         unreported=app.config['UNRESPONSIVE_HOURS'],
         with_status=True)
     nodes = []
+    report_status = {}
     for node in yield_or_stop(nodelist):
         if status_arg:
             if node.status == status_arg:
                 nodes.append(node)
         else:
             nodes.append(node)
+        reports = get_or_abort(puppetdb._query, 'reports',
+                               query='["=","certname","{0}"]'.format(node.name),
+                               limit=1)
+        if len(reports) > 0:
+            report_status[node.name] = reports[0]['status']
     return Response(stream_with_context(
-        stream_template('nodes.html', nodes=nodes)))
+        stream_template('nodes.html', nodes=nodes, report_status=report_status)))
 
 
 @app.route('/inventory')

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -323,12 +323,13 @@ def report(node_name, report_id):
 
     for report in reports:
         if report.hash_ == report_id or report.version == report_id:
-            events = puppetdb.events(query='["=", "report", "{0}"]'.format(
-                report.hash_))
+            events = report.events()
+            logs = iter(report.logs)
             return render_template(
                 'report.html',
                 report=report,
-                events=yield_or_stop(events))
+                events=yield_or_stop(events),
+                logs=yield_or_stop(logs))
     else:
         abort(404)
 

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -36,6 +36,50 @@ th.tablesorter-headerDesc::after {
   display: block;
 }
 
+.ui.header.failed, .ui.line.failed {
+  color: #AA4643;
+}
+
+.ui.label.failed {
+  background-color: #AA4643;
+}
+
+.ui.header.changed, .ui.line.changed {
+  color: #4572A7;
+}
+
+.ui.label.changed {
+  background-color: #4572A7;
+}
+
+.ui.header.unreported {
+  color: #3D96AE;
+}
+
+.ui.label.unreported {
+  background-color: #3D96AE;
+}
+
+.ui.header.noop {
+  color: #DB843D;
+}
+
+.ui.label.noop {
+  background-color: #DB843D;
+}
+
+.ui.label.unchanged {
+  background-color: #89A54E;
+}
+
+.ui.line.skipped {
+  color: orange;
+}
+
+.ui.label.skipped {
+  background-color: orange;
+}
+
 .count {
   width: 14%;
   text-align: center;

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -36,6 +36,11 @@ th.tablesorter-headerDesc::after {
   display: block;
 }
 
+.ui.label.status {
+  color: white;
+  text-shadow: 0 0 1px;
+}
+
 .ui.header.failed, .ui.line.failed {
   color: #AA4643;
 }

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -57,12 +57,32 @@ th.tablesorter-headerDesc::after {
   background-color: #4572A7;
 }
 
+.ui.label.changed.compil-failed {
+background: repeating-linear-gradient(
+  45deg,
+  #4572A7,
+  #4572A7 10px,
+  #AA4643 10px,
+  #AA4643 20px
+  );
+}
+
 .ui.header.unreported {
   color: #3D96AE;
 }
 
 .ui.label.unreported {
   background-color: #3D96AE;
+}
+
+.ui.label.unreported.compil-failed {
+background: repeating-linear-gradient(
+  45deg,
+  #3D96AE,
+  #3D96AE 10px,
+  #AA4643 10px,
+  #AA4643 20px
+  );
 }
 
 .ui.header.noop {
@@ -77,12 +97,32 @@ th.tablesorter-headerDesc::after {
   background-color: #89A54E;
 }
 
+.ui.label.unchanged.compil-failed {
+background: repeating-linear-gradient(
+  45deg,
+  #89A54E,
+  #89A54E 10px,
+  #AA4643 10px,
+  #AA4643 20px
+  );
+}
+
 .ui.line.skipped {
   color: orange;
 }
 
 .ui.label.skipped {
   background-color: orange;
+}
+
+.ui.label.skipped.compil-failed {
+background: repeating-linear-gradient(
+  45deg,
+  orange,
+  orange 10px,
+  #AA4643 10px,
+  #AA4643 20px
+  );
 }
 
 .count {

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -93,6 +93,10 @@ background: repeating-linear-gradient(
   background-color: #DB843D;
 }
 
+.ui.line.info {
+  color: #89A54E;
+}
+
 .ui.label.unchanged {
   background-color: #89A54E;
 }
@@ -107,7 +111,7 @@ background: repeating-linear-gradient(
   );
 }
 
-.ui.line.skipped {
+.ui.line.skipped, .ui.line.warning {
   color: orange;
 }
 
@@ -123,6 +127,10 @@ background: repeating-linear-gradient(
   #AA4643 10px,
   #AA4643 20px
   );
+}
+
+.break-all {
+  word-break: break-all;
 }
 
 .count {

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -87,11 +87,11 @@
                 {% elif node.status == 'unchanged' %}
                   unchanged
                 {% endif %}
-                {% if node.status != 'failed' and report_status[node.name] == 'failed' %}
+                {% if node.status != 'failed' and node.status != 'unreported' and report_status[node.name] == 'failed' %}
                   compil-failed
                 {% endif %}
                 " href="{{url_for('report_latest', node_name=node.name)}}">
-                {% if node.status != 'failed' and report_status[node.name] == 'failed' %}
+                {% if node.status != 'failed' and node.status != 'unreported' and report_status[node.name] == 'failed' %}
                   compilation failed ( {{node.status}})
                 {% else %}
                   {{node.status}}

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -4,7 +4,7 @@
   <div class="four column row">
     <div class="column">
       <a href="nodes?status=failed">
-        <h1 class="ui red header no-margin-bottom">
+        <h1 class="ui failed header no-margin-bottom">
           {{stats['failed']}}
           <small>{% if stats['failed']== 1 %} node {% else %} nodes {% endif %}</small>
         </h1>
@@ -13,7 +13,7 @@
     </div>
     <div class="column">
       <a href="nodes?status=noop">
-        <h1 class="ui header purple no-margin-bottom">
+        <h1 class="ui header noop no-margin-bottom">
           {{stats['noop']}}
           <small>{% if stats['noop']== 1 %} node {% else %} nodes {% endif %}</small>
         </h1>
@@ -22,7 +22,7 @@
     </div>
     <div class="column">
       <a href="nodes?status=changed">
-        <h1 class="ui header green no-margin-bottom">
+        <h1 class="ui header changed no-margin-bottom">
           {{stats['changed']}}
           <small>{% if stats['changed']== 1 %} node {% else %} nodes {% endif %}</small>
         </h1>
@@ -31,7 +31,7 @@
     </div>
     <div class="column">
       <a href="nodes?status=unreported">
-        <h1 class="ui header black no-margin-bottom">
+        <h1 class="ui header unreported no-margin-bottom">
           {{ stats['unreported'] }}
           <small>{% if stats['unreported']== 1 %} node {% else %} nodes {% endif %}</small>
         </h1>
@@ -77,13 +77,15 @@
             <td>
               <a class="ui small status label
                 {% if node.status == 'failed' %}
-                  red
+                  failed
                 {% elif node.status == 'changed' %}
-                  green
+                  changed
                 {% elif node.status == 'unreported' %}
-                  black
+                  unreported
                 {% elif node.status == 'noop' %}
-                  blue
+                  noop
+                {% elif node.status == 'unchanged' %}
+                  unchanged
                 {% endif %}
                 " href="{{url_for('report_latest', node_name=node.name)}}">
                   {{node.status}}
@@ -91,9 +93,9 @@
                 {% if node.status=='unreported'%}
                   <span class="ui small label status"> {{ node.unreported_time }} </span>
                 {% else %}
-                   {% if node.events['failures'] %}<span class="ui small count label red">{{node.events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
-                   {% if node.events['successes'] %}<span class="ui small count label green">{{node.events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
-                   {% if node.events['skips'] %}<span class="ui small count label yellow">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+                   {% if node.events['failures'] %}<span class="ui small count label failed">{{node.events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+                   {% if node.events['successes'] %}<span class="ui small count label changed">{{node.events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+                   {% if node.events['skips'] %}<span class="ui small count label skipped">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
                 {% endif %}
             </td>
             <td>

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -72,7 +72,7 @@
         </thead>
         <tbody class="searchable">
           {% for node in nodes %}
-          {% if node.status != 'unchanged' %}
+          {% if node.status != 'unchanged' or report_status[node.name] == 'failed' %}
           <tr>
             <td>
               <a class="ui small status label
@@ -87,8 +87,15 @@
                 {% elif node.status == 'unchanged' %}
                   unchanged
                 {% endif %}
+                {% if node.status != 'failed' and report_status[node.name] == 'failed' %}
+                  compil-failed
+                {% endif %}
                 " href="{{url_for('report_latest', node_name=node.name)}}">
+                {% if node.status != 'failed' and report_status[node.name] == 'failed' %}
+                  compilation failed ( {{node.status}})
+                {% else %}
                   {{node.status}}
+                {% endif %}
                 </a>
                 {% if node.status=='unreported'%}
                   <span class="ui small label status"> {{ node.unreported_time }} </span>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -29,11 +29,11 @@
           {% elif node.status == 'unchanged' %}
             unchanged
           {% endif %}
-          {% if node.status != 'failed' and  report_status[node.name] == 'failed' %}
+          {% if node.status != 'failed' and node.status != 'unreported' and report_status[node.name] == 'failed' %}
             compil-failed
           {% endif %}
           " href="{{url_for('report_latest', node_name=node.name)}}">
-          {% if node.status != 'failed' and report_status[node.name] == 'failed' %}
+          {% if node.status != 'failed' and node.status != 'unreported' and report_status[node.name] == 'failed' %}
             compilation failed ( {{node.status}})
           {% else %}
             {{node.status}}

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -29,8 +29,15 @@
           {% elif node.status == 'unchanged' %}
             unchanged
           {% endif %}
+          {% if node.status != 'failed' and  report_status[node.name] == 'failed' %}
+            compil-failed
+          {% endif %}
           " href="{{url_for('report_latest', node_name=node.name)}}">
+          {% if node.status != 'failed' and report_status[node.name] == 'failed' %}
+            compilation failed ( {{node.status}})
+          {% else %}
             {{node.status}}
+          {% endif %}
           </a>
           {% if node.status=='unreported'%}
             <span class="ui small label status"> {{ node.unreported_time }} </label>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -19,13 +19,15 @@
       <td>
         <a class="ui small status label
           {% if node.status == 'failed' %}
-            red
+            failed
           {% elif node.status == 'changed' %}
-            green
+            changed
           {% elif node.status == 'unreported' %}
-            black
+            unreported
           {% elif node.status == 'noop' %}
-            blue
+            noop
+          {% elif node.status == 'unchanged' %}
+            unchanged
           {% endif %}
           " href="{{url_for('report_latest', node_name=node.name)}}">
             {{node.status}}
@@ -33,9 +35,9 @@
           {% if node.status=='unreported'%}
             <span class="ui small label status"> {{ node.unreported_time }} </label>
           {% else %}
-          <span>{% if node.events['failures'] %}<span class="ui small count label red">{{node.events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
-            {% if node.events['successes'] %}<span class="ui small count label green">{{node.events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}</span>
-            {% if node.events['skips'] %}<span class="ui small count label yellow">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+          <span>{% if node.events['failures'] %}<span class="ui small count label failed">{{node.events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+            {% if node.events['successes'] %}<span class="ui small count label changed">{{node.events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}</span>
+            {% if node.events['skips'] %}<span class="ui small count label skipped">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
           {% endif %}
       </td>
       <td><a href="{{url_for('node', node_name=node.name)}}">{{node.name}}</a></td>

--- a/puppetboard/templates/report.html
+++ b/puppetboard/templates/report.html
@@ -39,9 +39,11 @@
   <tbody>
     {% for event in events %}
     {% if not event.failed and event.item['old'] != event.item['new'] %}
-      <tr id='event-{{loop.index}}' class='positive'>
+      <tr id='event-{{loop.index}}' class='ui line changed'>
     {% elif event.failed %}
-      <tr id='event-{{loop.index}}' class='error'>
+      <tr id='event-{{loop.index}}' class='ui line failed'>
+    {% else %}
+      <tr id='event-{{loop.index}}' class='ui line {{event.status}}'>
     {% endif %}
       <td>{{event.item['type']}}[{{event.item['title']}}]</td>
       <td>{{event.status}}</td>

--- a/puppetboard/templates/report.html
+++ b/puppetboard/templates/report.html
@@ -26,6 +26,36 @@
   </tbody>
 </table>
 
+<h1>Logs</h1>
+<table class='ui basic table compact'>
+  <thead>
+    <tr>
+      <th>Level</th><th>Source</th><th>Tags</th><th>Time</th><th>Message</th><th>File</th><th>Line</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for log in logs %}
+      <tr id='log-{{loop.index}}' class='ui line
+        {% if log['level'] == 'err' %}
+          failed
+        {% elif log['level'] == 'warning' %}
+          warning
+        {% elif log['level'] == 'info' %}
+          info
+        {% endif %}
+        '>
+        <td>{{log['level']}}</td>
+        <td>{{log['source']}}</td>
+        <td>{{log['tags']|join(', ')}}</td>
+        <td>{{log['time']}}</td>
+        <td>{{log['message']}}</td>
+        <td>{{log['file']}}</td>
+        <td>{{log['line']}}</td>
+      </tr>
+    {% endfor %} 
+  </tbody>
+</table>
+
 <h1>Events</h1>
 <table class='ui basic table compact'>
   <thead>


### PR DESCRIPTION
This embarks both #164 and #163.

Here are some screenshots:

### Overview with striped status

![Overview with striped status](https://cloud.githubusercontent.com/assets/650430/10343226/20eae688-6d1d-11e5-8d7b-c6a12c0ff210.png)

### Nodes list with striped status

![Nodes list with striped status](https://cloud.githubusercontent.com/assets/650430/10343263/47a2d8ee-6d1d-11e5-80dc-c6620ca78487.png)

### Logs in the report view:

![Notice logs](https://cloud.githubusercontent.com/assets/650430/10343440/0ce0bff4-6d1e-11e5-8b67-b8a651fc096a.png)

![Failed logs (truncated)](https://cloud.githubusercontent.com/assets/650430/10343462/26dab90a-6d1e-11e5-873d-7512f104e79f.png)

The last log screenshot is truncated as it requires scrolling to be viewed.