### PR TITLE
Add OVERVIEW_FILTER

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -140,7 +140,7 @@ def index(env):
     check_env(env, envs)
 
     if env == '*':
-        query = None
+        query = app.config['OVERVIEW_FILTER']
 
         prefix = 'puppetlabs.puppetdb.query.population'
         num_nodes = get_or_abort(
@@ -157,9 +157,11 @@ def index(env):
         metrics['avg_resources_node'] = "{0:10.0f}".format(
             avg_resources_node['Value'])
     else:
-        query = '["and", {0}]'.format(
-                ", ".join('["=", "{0}", "{1}"]'.format(field, env)
-                    for field in ['catalog_environment', 'facts_environment']))
+        conditions = ", ".join('["=", "{0}", "{1}"]'.format(field, env)
+                  for field in ['catalog_environment', 'facts_environment'])
+        if app.config['OVERVIEW_FILTER'] != None:
+            conditions += ", {0}".format(app.config['OVERVIEW_FILTER'])
+        query = '["and", {0}]'.format(conditions)
         num_nodes = get_or_abort(
             puppetdb._query,
             'nodes',

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -18,6 +18,7 @@ LOGLEVEL = 'info'
 REPORTS_COUNT = 10
 OFFLINE_MODE = False
 ENABLE_CATALOG = False
+OVERVIEW_FILTER = None
 GRAPH_FACTS = ['architecture',
                'clientversion',
                'domain',


### PR DESCRIPTION
This allows to filter out nodes in the overview by passing queries to the PuppetDB in the `OVERVIEW_FILTER` configuration parameter.

For example, if I don't want to see the machines whose certname matches `wrk`, I can use:

```
OVERVIEW_FILTER = '["not", ["~", "certname", "wrk"]]'
```