### PR TITLE
templates/catalog_compare: Switching from basic tables to fixed tables

### DIFF
--- a/puppetboard/templates/catalog_compare.html
+++ b/puppetboard/templates/catalog_compare.html
@@ -15,7 +15,7 @@
     </tr>
     <tr>
       <td>
-        <table class="ui basic table compact catalog">
+        <table class="ui fixed table compact catalog">
           <thead>
             <tr><th>Resources</th></tr>
           </thead>
@@ -29,7 +29,7 @@
         </table>
       </td>
       <td>
-        <table class="ui basic table compact catalog">
+        <table class="ui fixed table compact catalog">
           <thead>
             <tr><th>Resources</th></tr>
           </thead>
@@ -45,7 +45,7 @@
     </tr>
     <tr>
       <td>
-        <table class="ui basic table compact catalog">
+        <table class="ui fixed table compact catalog">
           <thead>
             <tr>
               <th>Edges</th>
@@ -65,7 +65,7 @@
         </table>
       </td>
       <td>
-        <table class="ui basic table compact catalog">
+        <table class="ui fixed table compact catalog">
           <thead>
             <tr>
               <th>Edge</th>


### PR DESCRIPTION
Fixed https://github.com/puppet-community/puppetboard/issues/193

Fixed Semantic UI tables set a fixed position on the applied tables
that do not affect the alignment with narrow browser windows. Downside
of this approach is that users will have to scroll horizontally to view
the entire catalog comparison.