### PR TITLE
Using new Node and Catalog fields available in pypuppetdb 0.2.1

### DIFF
--- a/puppetboard/templates/catalog.html
+++ b/puppetboard/templates/catalog.html
@@ -10,6 +10,7 @@
       <th>Hostname</th>
       <th>Version</th>
       <th>Transaction UUID</th>
+      <th>Code ID</th>
     </tr>
   </thead>
   <tbody>
@@ -17,6 +18,7 @@
       <td><a href="{{url_for('node', env=current_env, node_name=catalog.node)}}">{{catalog.node}}</a></td>
       <td>{{catalog.version}}</td>
       <td>{{catalog.transaction_uuid}}</td>
+      <td>{{catalog.code_id}}</td>
     </tr>
   </tbody>
 </table>

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -79,14 +79,22 @@
           {% if node.status != 'unchanged' %}
           <tr>
             <td>
-              {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env)}}
+              {% if node.latest_report_hash %}
+                {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env, report_hash=node.latest_report_hash)}}
+              {% else %}
+                {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env)}}
+              {% endif %}
             </td>
             <td>
               <a href="{{url_for('node', env=current_env, node_name=node.name)}}">{{ node.name }}</a>
             </td>
             <td>
               {% if node.report_timestamp %}
-              <a href="{{url_for('report_latest', env=current_env, node_name=node.name)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
+                {% if node.latest_report_hash %}
+                  <a href="{{url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
+                {% else %}
+                  <a href="{{url_for('report_latest', env=current_env, node_name=node.name)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
+                {% endif %}
               {% else %}
                 <i class="large ban circle icon"></i>
               {% endif %}

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -18,13 +18,21 @@
     {% for node in nodes %}
     <tr>
       <td>
-        {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env)}}
+        {% if node.latest_report_hash %}
+          {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env, report_hash=node.latest_report_hash)}}
+        {% else %}
+          {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env)}}
+        {% endif %}
       </td>
       <td><a href="{{url_for('node', env=current_env, node_name=node.name)}}">{{node.name}}</a></td>
       <td><a rel="utctimestamp" href="{{url_for('catalog_node', env=current_env, node_name=node.name)}}">{{node.catalog_timestamp}}</a></td>
       <td>
         {% if node.report_timestamp %}
-        <a href="{{url_for('report_latest', env=current_env, node_name=node.name)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
+          {% if node.latest_report_hash %}
+            <a href="{{url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
+          {% else %}
+            <a href="{{url_for('report_latest', env=current_env, node_name=node.name)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
+          {% endif %}
         {% else %}
           <i class="large ban circle icon"></i>
         {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Flask >= 0.10.1",
         "Flask-WTF >= 0.9.4, <= 0.9.5",
         "WTForms < 2.0",
-        "pypuppetdb >= 0.2.0, < 0.3.0",
+        "pypuppetdb >= 0.2.1, < 0.3.0",
         ],
     keywords="puppet puppetdb puppetboard",
     classifiers=[


### PR DESCRIPTION
Showing the Code ID field in the catalogs page. This is currently
unused in PuppetDB as of 3.2.2 but may be useful when it will be used

If available, using the latest_report_hash field of the node object
in the index and nodes templates for the link to the latest report
available for the node.

Updating the report_latest function in app.py to query the nodes
endpoint and redirecting using the latest_report_hash field if available.
If not query the reports endpoint for the node's latest report.