### PR TITLE
puppetboard/app.py: Protecting against ZeroDivisionErrors

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -174,8 +174,11 @@ def index(env):
                     env))
         metrics['num_nodes'] = num_nodes[0]['count']
         metrics['num_resources'] = num_resources[0]['count']
-        metrics['avg_resources_node'] = "{0:10.0f}".format(
-            (num_resources[0]['count'] / num_nodes[0]['count']))
+        try:
+            metrics['avg_resources_node'] = "{0:10.0f}".format(
+                (num_resources[0]['count'] / num_nodes[0]['count']))
+        except ZeroDivisionError:
+            metrics['avg_resources_node'] = 0
 
     nodes = get_or_abort(puppetdb.nodes,
         query=query,


### PR DESCRIPTION
This fixes https://github.com/voxpupuli/puppetboard/issues/220

If the PuppetDB instance is not being properly cleaned up, i.e. deactivated or
expired nodes leave environment(s) empty, the queries try to determine the average
resource count per node by dividing the resources in the current environment by
the number of nodes in the environment. This patch protects against such an event.