### PR TITLE
Fix error "AttributeError: 'module' object has no attribute

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ WTForms==1.0.5
 Werkzeug==0.9.4
 itsdangerous==0.23
 pypuppetdb==0.2.1
-requests==2.2.1
+requests==2.6.0


### PR DESCRIPTION
'PROTOCOL_SSLv3'"

Running debian 8.2 (jessie) I experience the following:

```
Traceback (most recent call last):
  File "dev.py", line 11, in <module>
    from puppetboard.app import app
  File "/srv/puppetboard/puppetboard/puppetboard/app.py", line 19, in <module>
    from pypuppetdb import connect
  File "/srv/puppetboard/virtenv-puppetboard/local/lib/python2.7/site-packages/pypuppetdb/__init__.py", line 61, in <module>
    from pypuppetdb.api import BaseAPI
  File "/srv/puppetboard/virtenv-puppetboard/local/lib/python2.7/site-packages/pypuppetdb/api/__init__.py", line 7, in <module>
    import requests
  File "/srv/puppetboard/virtenv-puppetboard/local/lib/python2.7/site-packages/requests/__init__.py", line 53, in <module>
    from .packages.urllib3.contrib import pyopenssl
  File "/srv/puppetboard/virtenv-puppetboard/local/lib/python2.7/site-packages/requests/packages/urllib3/contrib/pyopenssl.py", line 62, in <module>
    ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD,
AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'
```

Bumping 'requests' version fixes issue, as suggested here: http://stackoverflow.com/questions/28987891/patch-pyopenssl-for-sslv3-issue