### PR TITLE
utils.py: Adding logging to :func:`puppetboard.utils.get_or_abort`

### DIFF
--- a/puppetboard/utils.py
+++ b/puppetboard/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import json
+import logging
 
 from math import ceil
 from requests.exceptions import HTTPError, ConnectionError
@@ -9,6 +10,8 @@ from pypuppetdb.errors import EmptyResponseError
 
 from flask import abort
 
+
+log = logging.getLogger(__name__)
 
 def jsonprint(value):
     return json.dumps(value, indent=2, separators=(',', ': '))
@@ -23,10 +26,13 @@ def get_or_abort(func, *args, **kwargs):
     try:
         return func(*args, **kwargs)
     except HTTPError as e:
+        log.error(str(e))
         abort(e.response.status_code)
     except ConnectionError:
+        log.error(str(e))
         abort(500)
     except EmptyResponseError:
+        log.error(str(e))
         abort(204)
 
 


### PR DESCRIPTION
This fixes https://github.com/voxpupuli/puppetboard/issues/230

If there are any connection issues between PuppetBoard and the PuppetDB
instance there wasn't any obvious evidence in log files. This additional
logging added to utils.py logs errors whenever there is an HTTPError,
ConnectionError or EmptyResponseError in get_or_abort.