### PR TITLE
puppetboard/app.py: Removing :func:`puppetboard/report_latest`

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -535,59 +535,6 @@ def reports_node(env, node_name, page):
         current_env=env)
 
 
-@app.route('/report/latest/<node_name>', defaults={'env': app.config['DEFAULT_ENVIRONMENT']})
-@app.route('/<env>/report/latest/<node_name>')
-def report_latest(env, node_name):
-    """Redirect to the latest report of a given node.
-
-    :param env: Search for reports in this environment
-    :type env: :obj:`string`
-    :param node_name: Find the reports whose certname match this value
-    :type node_name: :obj:`string`
-    """
-    envs = environments()
-    check_env(env, envs)
-
-    if env == '*':
-        node_query = '["=", "certname", "{0}"]'.format(node_name)
-    else:
-        node_query = '["and",' \
-            '["=", "report_environment", "{0}"],' \
-            '["=", "certname", "{1}"]]'.format(env, node_name)
-
-    try:
-        node = next(get_or_abort(puppetdb.nodes,
-            query=node_query,
-            with_status=True))
-    except StopIteration:
-        abort(404)
-
-    if node.latest_report_hash is not None:
-        hash_ = node.latest_report_hash
-    else:
-        if env == '*':
-            query='["and",' \
-                '["=", "certname", "{0}"],' \
-                '["=", "latest_report?", true]]'.format(node.name)
-        else:
-            query='["and",' \
-                '["=", "environment", "{0}"],' \
-                '["=", "certname", "{1}"],' \
-                '["=", "latest_report?", true]]'.format(
-                    env,
-                    node.name)
-
-        reports = get_or_abort(puppetdb.reports, query=query)
-        try:
-            report = next(reports)
-            hash_ = report.hash_
-        except StopIteration:
-            abort(404)
-
-    return redirect(
-        url_for('report', env=env, node_name=node_name, report_id=hash_))
-
-
 @app.route('/report/<node_name>/<report_id>', defaults={'env': app.config['DEFAULT_ENVIRONMENT']})
 @app.route('/<env>/report/<node_name>/<report_id>')
 def report(env, node_name, report_id):

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -161,11 +161,7 @@
       unchanged
     {% endif -%}
   label status" href="
-    {% if report_hash -%}
-      {{url_for('report', env=current_env, node_name=node_name, report_id=report_hash)}}
-    {% else -%}
-      {{url_for('report_latest', env=current_env, node_name=node_name)}}
-    {% endif -%}
+    {{url_for('report', env=current_env, node_name=node_name, report_id=report_hash)}}
   ">
     {{ status|upper }}
   </a>

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -89,11 +89,7 @@
             </td>
             <td>
               {% if node.report_timestamp %}
-                {% if node.latest_report_hash %}
-                  <a href="{{url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
-                {% else %}
-                  <a href="{{url_for('report_latest', env=current_env, node_name=node.name)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
-                {% endif %}
+                <a href="{{url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
               {% else %}
                 <i class="large ban icon"></i>
               {% endif %}

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -28,11 +28,7 @@
       <td><a rel="utctimestamp" href="{{url_for('catalog_node', env=current_env, node_name=node.name)}}">{{node.catalog_timestamp}}</a></td>
       <td>
         {% if node.report_timestamp %}
-          {% if node.latest_report_hash %}
-            <a href="{{url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
-          {% else %}
-            <a href="{{url_for('report_latest', env=current_env, node_name=node.name)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
-          {% endif %}
+          <a href="{{url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
         {% else %}
           <i class="large darkblue ban icon"></i>
         {% endif %}


### PR DESCRIPTION
This fixes https://github.com/voxpupuli/puppetboard/issues/234

The report_latest() function was effectively deprecated when PuppetDB
introduced the latest_report_hash field in the Nodes endpoint response
format in version 3.2. With the breaking changes to PuppetDB 4.0.0
support this function can be safely removed.