### PR TITLE
reverse sort order to lump minorities in 'other' instead of majorities

### DIFF
--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -61,7 +61,7 @@
     value: 0,
     }
   ]
-  var fact_values = data.map(function(item) { return [item.label, item.value]; }).filter(function(item){return item[0];}).sort(function(a,b){return a[1] - b[1];});
+  var fact_values = data.map(function(item) { return [item.label, item.value]; }).filter(function(item){return item[0];}).sort(function(a,b){return b[1] - a[1];});
   var realdata = fact_values.slice(0, 15);
   var otherdata = fact_values.slice(15);
   if (otherdata.length > 0) {


### PR DESCRIPTION
I (and my colleagues) believe this sort order makes more sense. By lumping the lowest ranked results together instead of potentially the largest. (As an example we have 18 different CPUs and the other category accounted for 67% using the default sort or 1.2% when reversed. 