### PR TITLE
puppetboard/app.py: Protecting against ZeroDivisionErrors on calculat…

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -174,8 +174,11 @@ def index(env):
                     env))
         metrics['num_nodes'] = num_nodes[0]['count']
         metrics['num_resources'] = num_resources[0]['count']
-        metrics['avg_resources_node'] = "{0:10.0f}".format(
-            (num_resources[0]['count'] / num_nodes[0]['count']))
+        try:
+            metrics['avg_resources_node'] = "{0:10.0f}".format(
+                (num_resources[0]['count'] / num_nodes[0]['count']))
+        except ZeroDivisionError:
+            metrics['avg_resources_node'] = 0
 
     nodes = get_or_abort(puppetdb.nodes,
         query=query,


### PR DESCRIPTION
…ions

This (re-)fixes https://github.com/voxpupuli/puppetboard/issues/220

Corner cases where new installations or empty environments will return
zero resources and zero nodes, this will result in a ZeroDivisionError.
Now if this happens setting the average-resources-per-node to zero.