### PR TITLE
More Easily View All Reports

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -57,14 +57,9 @@ def stream_template(template_name, **context):
     rv.enable_buffering(5)
     return rv
 
-def url_for_pagination(page):
+def url_for_field(field, value):
     args = request.view_args.copy()
-    args['page'] = page
-    return url_for(request.endpoint, **args)
-
-def url_for_environments(env):
-    args = request.view_args.copy()
-    args['env'] = env
+    args[field] = value
     return url_for(request.endpoint, **args)
 
 def environments():
@@ -80,8 +75,7 @@ def check_env(env, envs):
     if env != '*' and env not in envs:
         abort(404)
 
-app.jinja_env.globals['url_for_pagination'] = url_for_pagination
-app.jinja_env.globals['url_for_environments'] = url_for_environments
+app.jinja_env.globals['url_for_field'] = url_for_field
 
 @app.context_processor
 def utility_processor():

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -370,17 +370,29 @@ def node(env, node_name):
     report_event_counts = {}
 
     for report in reports_events:
-        counts = get_or_abort(puppetdb.event_counts,
-            query='["and", ["=", "environment", "{0}"],' \
-                '["=", "certname", "{1}"], ["=", "report", "{2}"]]'.format(
-                    env,
-                    node_name,
-                    report.hash_),
-            summarize_by="certname")
-        try:
-            report_event_counts[report.hash_] = counts[0]
-        except IndexError:
-            report_event_counts[report.hash_] = {}
+        report_event_counts[report.hash_] = {}
+
+        for event in report.events():
+            if event.status == 'success':
+                try:
+                    report_event_counts[report.hash_]['successes'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['successes'] = 1
+            elif event.status == 'failure':
+                try:
+                    report_event_counts[report.hash_]['failures'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['failures'] = 1
+            elif event.status == 'noop':
+                try:
+                    report_event_counts[report.hash_]['noops'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['noops'] = 1
+            elif event.status == 'skipped':
+                try:
+                    report_event_counts[report.hash_]['skips'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['skips'] = 1
     return render_template(
         'node.html',
         node=node,
@@ -432,27 +444,29 @@ def reports(env, page):
         abort(404)
 
     for report in reports_events:
-        if env == '*':
-            event_count_query = '["and",' \
-                '["=", "certname", "{0}"],' \
-                '["=", "report", "{1}"]]'.format(
-                    report.node,
-                    report.hash_)
-        else:
-            event_count_query = '["and",' \
-                '["=", "environment", "{0}"],' \
-                '["=", "certname", "{1}"],' \
-                '["=", "report", "{2}"]]'.format(
-                    env,
-                    report.node,
-                    report.hash_)
-        counts = get_or_abort(puppetdb.event_counts,
-            query=event_count_query,
-            summarize_by="certname")
-        try:
-            report_event_counts[report.hash_] = counts[0]
-        except IndexError:
-            report_event_counts[report.hash_] = {}
+        report_event_counts[report.hash_] = {}
+
+        for event in report.events():
+            if event.status == 'success':
+                try:
+                    report_event_counts[report.hash_]['successes'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['successes'] = 1
+            elif event.status == 'failure':
+                try:
+                    report_event_counts[report.hash_]['failures'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['failures'] = 1
+            elif event.status == 'noop':
+                try:
+                    report_event_counts[report.hash_]['noops'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['noops'] = 1
+            elif event.status == 'skipped':
+                try:
+                    report_event_counts[report.hash_]['skips'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['skips'] = 1
     return Response(stream_with_context(stream_template(
         'reports.html',
         reports=yield_or_stop(reports),
@@ -482,11 +496,17 @@ def reports_node(env, node_name, page):
     check_env(env, envs)
 
     if env == '*':
-        query = '["=", "certname", "{0}"]]'.format(node_name)
+        query = '["=", "certname", "{0}"]'.format(node_name)
+        total_query = '["extract", [["function", "count"]],'\
+            '["=", "certname", "{0}"]'.format(node_name)
     else:
         query='["and",' \
             '["=", "environment", "{0}"],' \
-            '["=", "certname", "{1}"]]'.format(env, node_name),
+            '["=", "certname", "{1}"]]'.format(env, node_name)
+        total_query = '["extract", [["function", "count"]],' \
+            '["and",' \
+            '["=", "environment", "{0}"],' \
+            '["=", "certname", "{1}"]]]'.format(env, node_name)
 
     reports = get_or_abort(puppetdb.reports,
         query=query,
@@ -495,10 +515,7 @@ def reports_node(env, node_name, page):
         order_by='[{"field": "start_time", "order": "desc"}]')
     total = get_or_abort(puppetdb._query,
         'reports',
-        query='["extract", [["function", "count"]],' \
-            '["and", ["=", "environment", "{0}"], ["=", "certname", "{1}"]]]'.format(
-            env,
-            node_name))
+        query=total_query)
     total = total[0]['count']
     reports, reports_events = tee(reports)
     report_event_counts = {}
@@ -507,27 +524,29 @@ def reports_node(env, node_name, page):
         abort(404)
 
     for report in reports_events:
-        if env == '*':
-            event_count_query = '["and",' \
-                '["=", "certname", "{0}"],' \
-                '["=", "report", "{1}"]]'.format(
-                    report.node,
-                    report.hash_)
-        else:
-            event_count_query = '["and",' \
-                '["=", "environment", "{0}"],' \
-                '["=", "certname", "{1}"],' \
-                '["=", "report", "{2}"]]'.format(
-                    env,
-                    report.node,
-                    report.hash_)
-        counts = get_or_abort(puppetdb.event_counts,
-            query=event_count_query,
-            summarize_by="certname")
-        try:
-            report_event_counts[report.hash_] = counts[0]
-        except IndexError:
-            report_event_counts[report.hash_] = {}
+        report_event_counts[report.hash_] = {}
+
+        for event in report.events():
+            if event.status == 'success':
+                try:
+                    report_event_counts[report.hash_]['successes'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['successes'] = 1
+            elif event.status == 'failure':
+                try:
+                    report_event_counts[report.hash_]['failures'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['failures'] = 1
+            elif event.status == 'noop':
+                try:
+                    report_event_counts[report.hash_]['noops'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['noops'] = 1
+            elif event.status == 'skipped':
+                try:
+                    report_event_counts[report.hash_]['skips'] += 1
+                except KeyError:
+                    report_event_counts[report.hash_]['skips'] = 1
     return render_template(
         'reports.html',
         reports=reports,

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -176,13 +176,13 @@
 {% macro render_pagination(pagination) -%}
   <div class="ui pagination menu">
   {% if pagination.has_prev %}
-    <a class="item" href="{{url_for_pagination(1)}}">&laquo; First</a>
-    <a class="item" href="{{url_for_pagination(pagination.page - 1)}}">Prev</a>
+    <a class="item" href="{{url_for_field('page', 1)}}">&laquo; First</a>
+    <a class="item" href="{{url_for_field('page', pagination.page - 1)}}">Prev</a>
   {% endif %}
   {% for page in pagination.iter_pages() %}
     {% if page %}
       {% if page != pagination.page %}
-        <a class="item" href="{{url_for_pagination(page)}}">{{page}}</a>
+        <a class="item" href="{{url_for_field('page', page)}}">{{page}}</a>
       {% else %}
         <a class="active item">{{page}}</a>
       {% endif %}
@@ -191,8 +191,8 @@
     {% endif %}
   {% endfor %}
   {% if pagination.has_next %}
-    <a class="item" href="{{url_for_pagination(pagination.page + 1)}}">Next</a>
-    <a class="item" href="{{url_for_pagination(pagination.pages)}}">Last &raquo;</a>
+    <a class="item" href="{{url_for_field('page', pagination.page + 1)}}">Next</a>
+    <a class="item" href="{{url_for_field('page', pagination.pages)}}">Last &raquo;</a>
   {% endif %}
   </div>
 {% endmacro %}

--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -42,9 +42,9 @@
         Environments
         <i class="dropdown icon"></i>
         <div class="menu">
-            <a class="{% if '*' == current_env %}active {% endif %}item" href="{{url_for_environments('*')}}">All environments</a>
+            <a class="{% if '*' == current_env %}active {% endif %}item" href="{{url_for_field('env', '*')}}">All environments</a>
           {% for env in envs %}
-            <a class="{% if env == current_env %}active {% endif %}item" href="{{url_for_environments(env)}}">{{env}}</a>
+            <a class="{% if env == current_env %}active {% endif %}item" href="{{url_for_field('env', env)}}">{{env}}</a>
           {% endfor %}
         </div>
       </div>

--- a/puppetboard/templates/node.html
+++ b/puppetboard/templates/node.html
@@ -29,6 +29,7 @@
     <div class='row'>
       <h1>Reports</h1>
       {{ macros.reports_table(reports, reports_count, report_event_counts, condensed=True, hash_truncate=True, show_conf_col=False, show_agent_col=False, show_host_col=False, current_env=current_env)}}
+      <a href="{{url_for('reports_node', node_name=node.name)}}">Show All</a>
     </div>
   </div>
   <div class='column'>

--- a/puppetboard/templates/reports.html
+++ b/puppetboard/templates/reports.html
@@ -3,4 +3,15 @@
 {% block content %}
 {{ macros.reports_table(reports, reports_count, report_event_counts, condensed=False, hash_truncate=False, show_conf_col=True, show_agent_col=True, show_host_col=True, show_search_bar=True, searchable=True, current_env=current_env)}}
 {{ macros.render_pagination(pagination)}}
+<div class="ui dropdown" style="float:right;">
+  <div class="text">Limit</div>
+  <i class="dropdown icon"></i>
+  <div class="menu">
+    <a class="{% if limit == config.REPORTS_COUNT %}active {% endif %}item" href="{{url_for_field('limit', config.REPORTS_COUNT)}}">{{config.REPORTS_COUNT}}</a>
+    <a class="{% if limit == 25 %}active {% endif %}item" href="{{url_for_field('limit', 25)}}">25</a>
+    <a class="{% if limit == 50 %}active {% endif %}item" href="{{url_for_field('limit', 50)}}">50</a>
+    <a class="{% if limit == 100 %}active {% endif %}item" href="{{url_for_field('limit', 100)}}">100</a>
+    <a class="{% if limit == '*' %}active {% endif %}item" href="{{url_for_field('limit', '*')}}">All</a>
+  </div>
+</div>
 {% endblock content %}


### PR DESCRIPTION
This resolves #202 

The fix for this issue has to come in 3 parts:

1. Replace the reports table status information originally populated by querying the event-counts endpoint with querying the current report's events. This was functionally nor required but this reduces the risk of loosing environment filters on the event-count queries.
2. Replace the `url_for_pagination()` and `url_for_environments()` function with a new `url_for_field()`. This new function updates a single request argument with a new value and returns the generated URL for the request endpoint.
3. Add a dropdown menu on the `reports()` and `reports_node()` pages to change the limit of the number of reports displayed on the page. 