### PR TITLE
puppetboard/utils.py: fix Python3 compatibility

### DIFF
--- a/puppetboard/utils.py
+++ b/puppetboard/utils.py
@@ -11,6 +11,12 @@ from pypuppetdb.errors import EmptyResponseError
 from flask import abort
 
 
+# Python 3 compatibility
+try:
+    xrange
+except NameError:
+    xrange = range
+
 log = logging.getLogger(__name__)
 
 def jsonprint(value):


### PR DESCRIPTION
If `xrange()` is not defined, alias it to `range()`.