### PR TITLE
PuppetBoard: Upgrading WTForms to latest version and restoring CSRF Protection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,24 @@ puppetboard directory:
 
 Make sure this file is readable by the user the webserver runs as.
 
+Flask requires a static secret_key in order to protect itself from CSRF exploits.
+The default secret_key in ``default_settings.py`` generates a random 24 character
+string, however this string is re-generated on each request under httpd >= 2.4.
+To generate your own secret_key create a python script with the following content
+and run it once:
+
+.. code_block:: python
+
+    import os
+
+    print os.random(24)
+
+Copy the output and add the following to your ``wsgi.py`` file:
+
+.. code_block:: python
+
+   application.secret_key = '<your secret key>'
+
 The last thing we need to do is configure Apache.
 
 Here is a sample configuration for Debian and Ubuntu:

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -13,7 +13,7 @@ from itertools import tee
 from flask import (
     Flask, render_template, abort, url_for,
     Response, stream_with_context, redirect,
-    request
+    request, session
     )
 
 from pypuppetdb import connect
@@ -699,7 +699,9 @@ def query(env):
         envs = environments()
         check_env(env, envs)
 
-        form = QueryForm(csrf_enabled=False)
+        form = QueryForm(meta={
+            'csrf_secret': app.config['SECRET_KEY'],
+            'csrf_context': session})
         if form.validate_on_submit():
             if form.query.data[0] == '[':
                 query = form.query.data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Flask==0.10.1
-Flask-WTF==0.9.4
+Flask-WTF==0.12
 Jinja2==2.7.2
 MarkupSafe==0.19
-WTForms==1.0.5
-Werkzeug==0.9.4
+WTForms==2.1
+Werkzeug==0.11.10
 itsdangerous==0.23
-pypuppetdb==0.2.1
+pypuppetdb==0.2.3
 requests==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     long_description='\n'.join((README, CHANGELOG)),
     install_requires=[
         "Flask >= 0.10.1",
-        "Flask-WTF >= 0.9.4, <= 0.9.5",
-        "WTForms < 2.0",
+        "Flask-WTF >= 0.12, <= 0.13",
+        "WTForms < 3.0",
         "pypuppetdb >= 0.2.1, < 0.3.0",
         ],
     keywords="puppet puppetdb puppetboard",


### PR DESCRIPTION
This fixes #243 

Upgrading the following packages to the respected versions:

WTForms==2.1
Flask-WTF==0.12
Werkzeug==0.11.0

Passing newly required metadata to the QueryForm constructor in puppetboard/app.py

Apache >= 2.4 with mod_wsgi experienced a major issue where it would re-generate
the app's secret key on each request. The fix for this turned out to be placing
a permanent statis 'secret_key' value in the wsgi.py. Adding a block in README.rst
on how to implement the user's own secret_key