### PR TITLE
Removing redudant declaration of upstream in Nginx example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -501,10 +501,6 @@ differ too much. As we can't use ``uwsgi_pass`` with gunicorn, the nginx configu
 
 .. code-block:: nginx
 
-    upstream puppetboard {
-        server 127.0.0.1:9090;
-    }
-
     server {
         listen      80;
         server_name puppetboard.example.tld;


### PR DESCRIPTION
With the IP address of the gunicorn server set in proxy_pass, the configuration example doesn't need to declare an upstream server.