### PR TITLE
puppetboard/app.py: Using the plain-text metric name in metrics()

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -771,10 +771,8 @@ def metrics(env):
     check_env(env, envs)
 
     metrics = get_or_abort(puppetdb._query, 'mbean')
-    for key, value in metrics.items():
-        metrics[key] = value.split('/')[2]
     return render_template('metrics.html',
-        metrics=sorted(metrics.items()),
+        metrics=sorted(metrics.keys()),
         envs=envs,
         current_env=env)
 

--- a/puppetboard/templates/metrics.html
+++ b/puppetboard/templates/metrics.html
@@ -2,8 +2,8 @@
 {% block content %}
 <h1>Metrics</h1>
 <ul>
-  {% for key,value in metrics %}
-  <li><a href="{{url_for('metric', env=current_env, metric=value)}}">{{key}}</li>
+  {% for metric in metrics %}
+  <li><a href="{{url_for('metric', env=current_env, metric=metric)}}">{{metric}}</li>
   {% endfor %}
 </ul>
 {% endblock content %}


### PR DESCRIPTION
This fixes #258

URL quoting is now done in pypuppetdb >= 0.2.3 which contributed to the
metric URL being double-quoted by the time it reached PuppetDB, which
responds with a 404. Instead using the plain-text name to build the
link to metric()