### PR TITLE
puppetboard/default_settings.py: Reverting PUPPETDB_HOST change from …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,13 @@ Native packages for your operating system will be provided in the near future.
 .. _OpenSuSE 12/13: https://build.opensuse.org/package/show/systemsmanagement:puppet/python-puppetboard
 .. _SuSE LE 11 SP3: https://build.opensuse.org/package/show/systemsmanagement:puppet/python-puppetboard
 
+Docker Images
+^^^^^^^^^^^^^
+
+A `Dockerfile`_ was added to the source-code in the 0.2.0 release. An officially
+image is planned for the 0.2.x series.
+
+.. _Dockerfile: https://github.com/voxpupuli/puppetboard/blob/master/Dockerfile
 
 Development
 -----------

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -1,6 +1,6 @@
 import os
 
-PUPPETDB_HOST = 'puppetdb'
+PUPPETDB_HOST = 'localhost'
 PUPPETDB_PORT = 8080
 PUPPETDB_SSL_VERIFY = True
 PUPPETDB_KEY = None


### PR DESCRIPTION
…#187

This change is only useful for Docker image building, but for officially
supported packages in PIP this change will cause unnecessary breakage to
existing users. We will have to implement a different approach for configuring
settings in Docker images.

Adding a note to README.rst indicating that an officially supported Docker
image is planned.