### PR TITLE
Fix radiator view auto-resize

### DIFF
--- a/puppetboard/static/js/jquery.min.js
+++ b/puppetboard/static/js/jquery.min.js
@@ -1,0 +1,1 @@
+../jquery-2.1.1/jquery.min.js


### PR DESCRIPTION
Radiator view is broken in 0.2.0 due to absence of /static/js/jquery.min.js 
This patch creates symlink to required /puppetboard/static/jquery-2.1.1/jquery.min.js in puppetboard/static/js