### PR TITLE
puppetboard/app.py: Enhancing queries for Node and Report states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,7 +300,7 @@ string, however this string is re-generated on each request under httpd >= 2.4.
 To generate your own secret_key create a python script with the following content
 and run it once:
 
-.. code_block:: python
+.. code-block:: python
 
     import os
 
@@ -308,7 +308,7 @@ and run it once:
 
 Copy the output and add the following to your ``wsgi.py`` file:
 
-.. code_block:: python
+.. code-block:: python
 
    application.secret_key = '<your secret key>'
 

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -448,28 +448,22 @@ def reports(env, page):
     check_env(env, envs)
     limit = request.args.get('limit', app.config['REPORTS_COUNT'])
     status_arg = request.args.get('status')
-    reports_query = None
+    reports_query = AndOperator()
     total_query = ExtractOperator()
 
     total_query.add_field(FunctionOperator("count"))
 
-    if env == '*':
-        if status_arg in ['failed', 'changed', 'unchanged']:
-            reports_query = AndOperator()
-            reports_query.add(EqualsOperator('status', status_arg))
-            reports_query.add(EqualsOperator('noop', False))
-        elif status_arg == 'noop':
-            reports_query = EqualsOperator('noop', True)
-    else:
-        reports_query = AndOperator()
+    if env != '*':
         reports_query.add(EqualsOperator("environment", env))
 
-        if status_arg in ['failed', 'changed', 'unchanged']:
-            reports_query = AndOperator()
-            reports_query.add(EqualsOperator('status', status_arg))
-            reports_query.add(EqualsOperator('noop', False))
-        elif status_arg == 'noop':
-            reports_query = EqualsOperator('noop', True)
+    if status_arg in ['failed', 'changed', 'unchanged']:
+        reports_query.add(EqualsOperator('status', status_arg))
+        reports_query.add(EqualsOperator('noop', False))
+    elif status_arg == 'noop':
+        reports_query.add(EqualsOperator('noop', True))
+
+    if len(reports_query.operations) == 0:
+        reports_query = None
 
     if reports_query is not None:
         total_query.add_query(reports_query)

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -254,17 +254,17 @@ def nodes(env):
         query.add(EqualsOperator("catalog_environment", env))
         query.add(EqualsOperator("facts_environment", env))
 
-
     if status_arg in ['failed', 'changed', 'unchanged']:
         query.add(EqualsOperator('latest_report_status', status_arg))
     elif status_arg == 'unreported':
         unreported = datetime.datetime.utcnow()
-        unreported = unreported - timedelta(hours=app.config['UNRESPONSIVE_HOURS'])
-        unreported = unreported.replace(microsecond=0)
+        unreported = (unreported -
+                      timedelta(hours=app.config['UNRESPONSIVE_HOURS']))
+        unreported = unreported.replace(microsecond=0).isoformat()
 
         unrep_query = OrOperator()
         unrep_query.add(NullOperator('report_timestamp', True))
-        unrep_query.add(LessEqualOperator('report_timestamp', unreported.isoformat()))
+        unrep_query.add(LessEqualOperator('report_timestamp', unreported))
 
         query.add(unrep_query)
 

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -42,4 +42,15 @@
     {% endfor %}
   </tbody>
 </table>
+<div class="ui dropdown" style="float:right;">
+  <div class="text">Filter By</div>
+  <i class="dropdown icon"></i>
+  <div class="menu">
+    <a class="item" href="{{url_for_field('status', 'failed')}}">Failed</a>
+    <a class="item" href="{{url_for_field('status', 'changed')}}">Changed</a>
+    <a class="item" href="{{url_for_field('status', 'unchanged')}}">Unchanged</a>
+    <a class="item" href="{{url_for_field('status', 'noop')}}">Noop</a>
+    <a class="item" href="{{url_for_field('status', 'unreported')}}">Unreported</a>
+  </div>
+</div>
 {% endblock content %}

--- a/puppetboard/templates/reports.html
+++ b/puppetboard/templates/reports.html
@@ -14,4 +14,14 @@
     <a class="{% if limit == '*' %}active {% endif %}item" href="{{url_for_field('limit', '*')}}">All</a>
   </div>
 </div>
+<div class="ui dropdown" style="float:right;">
+  <div class="text">Filter By</div>
+  <i class="dropdown icon"></i>
+  <div class="menu">
+    <a class="item" href="{{url_for_field('status', 'failed')}}">Failed</a>
+    <a class="item" href="{{url_for_field('status', 'changed')}}">Changed</a>
+    <a class="item" href="{{url_for_field('status', 'unchanged')}}">Unchanged</a>
+    <a class="item" href="{{url_for_field('status', 'noop')}}">Noop</a>
+  </div>
+</div>
 {% endblock content %}


### PR DESCRIPTION
This resolves #264

On the Nodes and Reports tabs when the user adds a status query string
argument additional query clauses are generated based on its value.
Can be one of failed, changed, unchanged, noop or unreported (for Nodes
only)

No query clause is generated for noop on the Nodes tab. The query field
latest_report_noop was added in PuppetDB 4.1 and we do not want to break
compatability between minor or bug-fix versions.