### PR TITLE
Update radiator view

### DIFF
--- a/puppetboard/static/js/jquery.min.map
+++ b/puppetboard/static/js/jquery.min.map
@@ -1,1 +1,0 @@
-../jquery-2.1.1/jquery.min.map

--- a/puppetboard/templates/radiator.html
+++ b/puppetboard/templates/radiator.html
@@ -6,7 +6,11 @@
     <meta http-equiv='refresh' content="{{config.REFRESH_RATE}}"/>
     {% endif %}
     <link href="{{ url_for('static', filename='css/radiator.css')}}" media="screen" rel="stylesheet" type="text/css" />
-    <script src="{{ url_for('static', filename='js/jquery.min.js')}}" type="text/javascript"></script>
+    {% if config.OFFLINE_MODE %}
+        <script src="{{ url_for('static', filename='jquery-2.1.1/jquery.min.js') }}"></script>
+    {% else %}
+        <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    {% endif %}
     <script src="{{ url_for('static', filename='js/radiator.js')}}" type="text/javascript"></script>
 </head>
 <body class='radiator_controller radiator_index_action no-sidebar'>


### PR DESCRIPTION
Radiatorview was using the wrong link for jquery.js. Which was found by @amuametov

Adding in the OFFLINE setting which is used to determine local or remote JS.

Removing symlink of jquery.min.map, which is not referenced anywhere.

Closes #269 and #270 
