### PR TITLE
Add coveralls.io badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,9 @@
 Puppetboard
 ###########
 
-.. image:: https://travis-ci.org/voxpupuli/puppetboard.svg?branch=add_travis_badge
-    :target: https://travis-ci.org/voxpupuli/puppetboard
+.. image:: https://travis-ci.org/voxpupuli/puppetboard.svg?branch=add_travis_badge :target: https://travis-ci.org/voxpupuli/puppetboard
+
+.. image:: https://coveralls.io/repos/github/voxpupuli/puppetboard/badge.svg?branch=master :target: https://coveralls.io/github/voxpupuli/puppetboard?branch=master
 
 Puppetboard is a web interface to `PuppetDB`_ aiming to replace the reporting
 functionality of `Puppet Dashboard`_.


### PR DESCRIPTION
coveralls.io badge.

Is there better way to reference the badge?  so that the README.rst knows who's linking to it?