### PR TITLE
Fix rst syntax for badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,11 @@
 Puppetboard
 ###########
 
-.. image:: https://travis-ci.org/voxpupuli/puppetboard.svg?branch=add_travis_badge :target: https://travis-ci.org/voxpupuli/puppetboard
+.. image:: https://travis-ci.org/voxpupuli/puppetboard.svg?branch=master
+   :target:  https://travis-ci.org/voxpupuli/puppetboard
 
-.. image:: https://coveralls.io/repos/github/voxpupuli/puppetboard/badge.svg?branch=master :target: https://coveralls.io/github/voxpupuli/puppetboard?branch=master
+.. image:: https://coveralls.io/repos/github/voxpupuli/puppetboard/badge.svg?branch=master
+   :target:  https://coveralls.io/github/voxpupuli/puppetboard?branch=master
 
 Puppetboard is a web interface to `PuppetDB`_ aiming to replace the reporting
 functionality of `Puppet Dashboard`_.


### PR DESCRIPTION
* Require links to be on newline

Before:
<img width="245" alt="screenshot 2016-07-15 09 39 41" src="https://cloud.githubusercontent.com/assets/1064715/16868538/11d8f5aa-4a70-11e6-87a1-b656a5ef2731.png">

After:
<img width="216" alt="screenshot 2016-07-15 09 40 09" src="https://cloud.githubusercontent.com/assets/1064715/16868553/24481c3e-4a70-11e6-82e3-ac669cfb3554.png">

Helping hand from http://stackoverflow.com/questions/14087784/linked-image-in-restructuredtext
