### PR TITLE
Add a setting to hide fact values from the node page.

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -379,6 +379,11 @@ def node(env, node_name):
     reports, reports_events = tee(reports)
     report_event_counts = {}
 
+    try:
+        hidden_facts_values = app.config['HIDE_FACTS_VALUES_FROM_NODE_VIEW']
+    except:
+        hidden_facts_values = []
+
     for report in reports_events:
         report_event_counts[report.hash_] = {}
 
@@ -411,6 +416,7 @@ def node(env, node_name):
         reports_count=app.config['REPORTS_COUNT'],
         report_event_counts=report_event_counts,
         envs=envs,
+        hidden_facts_values=hidden_facts_values,
         current_env=env)
 
 

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -38,3 +38,4 @@ INVENTORY_FACTS = [('Hostname', 'fqdn'),
                    ('Kernel Version', 'kernelrelease'),
                    ('Puppet Version', 'puppetversion'), ]
 REFRESH_RATE = 30
+HIDE_FACTS_VALUES_FROM_NODE_VIEW = []

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -1,4 +1,4 @@
-{% macro facts_table(facts, current_env, autofocus=False, condensed=False, show_node=False, show_value=True, link_facts=False, margin_top=20, margin_bottom=20) -%}
+{% macro facts_table(facts, current_env, autofocus=False, condensed=False, show_node=False, show_value=True, link_facts=False, margin_top=20, margin_bottom=20, hidden_facts_values=[]) -%}
 <div class="ui fluid icon input hide" style="margin-bottom:20px">
   <input {% if autofocus %} autofocus="autofocus" {% endif %} class="filter-table" placeholder="Type here to filter...">
 </div>
@@ -25,17 +25,21 @@
       {% endif %}
       {% if show_value %}
       <td style="word-wrap:break-word">
-        {% if link_facts %}
-          {% if fact.value is mapping %}
-            <a href="{{url_for('fact_value', env=current_env, fact=fact.name, value=fact.value)}}"><pre>{{fact.value|jsonprint}}</pre></a>
+        {% if fact.name in hidden_facts_values %}
+          <a>HIDDEN</pre>
+        {% else %}      
+          {% if link_facts %}
+            {% if fact.value is mapping %}
+              <a href="{{url_for('fact_value', env=current_env, fact=fact.name, value=fact.value)}}"><pre>{{fact.value|jsonprint}}</pre></a>
+            {% else %}
+              <a href="{{url_for('fact_value', env=current_env, fact=fact.name, value=fact.value)}}">{{fact.value}}</a>
+            {% endif %}
           {% else %}
-            <a href="{{url_for('fact_value', env=current_env, fact=fact.name, value=fact.value)}}">{{fact.value}}</a>
-          {% endif %}
-        {% else %}
-          {% if fact.value is mapping %}
-            <pre>{{fact.value|jsonprint}}</pre>
-          {% else %}
-            {{fact.value}}
+            {% if fact.value is mapping %}
+              <pre>{{fact.value|jsonprint}}</pre>
+            {% else %}
+              {{fact.value}}
+            {% endif %}
           {% endif %}
         {% endif %}
       </td>

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -26,7 +26,7 @@
       {% if show_value %}
       <td style="word-wrap:break-word">
         {% if fact.name in hidden_facts_values %}
-          <a>HIDDEN</pre>
+          <pre>HIDDEN</pre>
         {% else %}      
           {% if link_facts %}
             {% if fact.value is mapping %}

--- a/puppetboard/templates/node.html
+++ b/puppetboard/templates/node.html
@@ -34,7 +34,7 @@
   </div>
   <div class='column'>
     <h1>Facts</h1>
-    {{macros.facts_table(facts, link_facts=True, condensed=True, current_env=current_env)}}
+    {{macros.facts_table(facts, link_facts=True, condensed=True, current_env=current_env, hidden_facts_values=hidden_facts_values))}}
   </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
Allows the use of a new setting to hide fact values from the node page. This is quite useful on facts which return large results.
Example is the one fact which returns a list of services installed in the OS with some meta information polled from each service.
