### PR TITLE
Make node row in inventory link to node page

### DIFF
--- a/puppetboard/templates/inventory.html
+++ b/puppetboard/templates/inventory.html
@@ -15,7 +15,7 @@
     {% for nodename in nodedata %}
     <tr>
       {% for item in nodedata[nodename] %}
-      <td>{{item}}</td>
+      <td><a href="{{url_for('node', env=current_env, node_name=nodename)}}">{{item}}</a></td>
       {% endfor %}
     </tr>
     {% endfor %}


### PR DESCRIPTION
To improve UX, made each element in an inventory row clickable to get to the node page.