### PR TITLE
Travis: run tests under python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.5"
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-test.txt


### PR DESCRIPTION
Looks like things run well under python 3.5 on our Ubuntu 16.04 install with PuppetDB 4.x. Run tests on python 3.5 to make sure things do not break.