### PR TITLE
Pagination prototype

### DIFF
--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -6,19 +6,30 @@ PUPPETDB_SSL_VERIFY = True
 PUPPETDB_KEY = None
 PUPPETDB_CERT = None
 PUPPETDB_TIMEOUT = 20
-DEFAULT_ENVIRONMENT = 'production'
+
+DEFAULT_ENVIRONMENT = '*'
+
 SECRET_KEY = os.urandom(24)
+
 DEV_LISTEN_HOST = '127.0.0.1'
 DEV_LISTEN_PORT = 5000
 DEV_COFFEE_LOCATION = 'coffee'
+
 UNRESPONSIVE_HOURS = 2
 ENABLE_QUERY = True
 LOCALISE_TIMESTAMP = True
 LOGLEVEL = 'info'
+
+# Records number per page (set to False disable paging)
+DEFAULT_PAGE_SIZE = 50
+
+#
 REPORTS_COUNT = 10
+
 OFFLINE_MODE = False
 ENABLE_CATALOG = False
 OVERVIEW_FILTER = None
+
 GRAPH_FACTS = ['architecture',
                'clientversion',
                'domain',
@@ -37,4 +48,5 @@ INVENTORY_FACTS = [('Hostname', 'fqdn'),
                    ('Architecture', 'hardwaremodel'),
                    ('Kernel Version', 'kernelrelease'),
                    ('Puppet Version', 'puppetversion'), ]
+
 REFRESH_RATE = 30

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -113,4 +113,7 @@
     </div>
   </div>
 </div>
+<br />
+{{ macros.render_pagination(pagination)}}
+<br /><br />
 {% endblock content %}


### PR DESCRIPTION
Hi,

I recently installed puppetboard, but was not able to go in production. With thousands hosts, I got some issues with response time and laggy browser.

I am trying to patch in order to get pagination everywhere (PR code). But, I'm kinda stuck with pypuppetdb nodes endpoint. I can not find a reliable way to count nodes on status.

Looking at pypuppetdb, this situation is normal as status is determined only after request. Do you think (in a reasonable future) every field can / may be suitable for filter or count ?

I am available to work on it if this is ok for you.