### PR TITLE
puppetboard/templates/layout.html: Displaying the current active envi…

### DIFF
--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -39,7 +39,7 @@
         href="{{ url_for(endpoint, env=current_env) }}">{{ caption }}</a>
       {%- endfor %}
       <div class="ui dropdown item">
-        Environments
+        {{current_env}}
         <i class="dropdown icon"></i>
         <div class="menu">
             <a class="{% if '*' == current_env %}active {% endif %}item" href="{{url_for_field('env', '*')}}">All environments</a>


### PR DESCRIPTION
…ronment as the dropdown label

This fixed #290

To help make it more obvious for users to see what the current environment
is replacing the original text of the Environments dropdown menu from
'Environments' to the current environment.

The other suggestion was to make the active item stand out more but that
would require custom CSS that may conflict with the Sementic UI.