### PR TITLE
Change hostname to certname where applicable

### DIFF
--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -95,7 +95,7 @@
       <th class="default-sort">Start time</th>
       <th>Status</th>
       {% if show_host_col %}
-        <th>Hostname</th>
+        <th>Certname</th>
       {% endif %}
       {% if show_run_col %}
       <th>Run time</th>

--- a/puppetboard/templates/catalog.html
+++ b/puppetboard/templates/catalog.html
@@ -7,7 +7,7 @@
 <table class='ui very basic very compact table'>
   <thead>
     <tr>
-      <th>Hostname</th>
+      <th>Certname</th>
       <th>Version</th>
       <th>Transaction UUID</th>
       <th>Code ID</th>

--- a/puppetboard/templates/catalogs.html
+++ b/puppetboard/templates/catalogs.html
@@ -8,7 +8,7 @@
   <thead>
     <tr>
       <th></th>
-      <th>Hostname</th>
+      <th>Certname</th>
       <th>Compile Time</th>
       <th>Compare With</th>
     </tr>

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -68,7 +68,7 @@
         <thead>
           <tr>
             <th class="five wide">Status</th>
-            <th class="five wide">Hostname</th>
+            <th class="five wide">Certname</th>
             <th class="five wide date default-sort">Report</th>
             <th class="one wide"></th>
           </tr>

--- a/puppetboard/templates/node.html
+++ b/puppetboard/templates/node.html
@@ -8,7 +8,7 @@
       <table class="ui very basic very compact table">
         <tbody>
           <tr>
-            <th>Hostname</th>
+            <th>Certname</th>
             <td style="word-wrap:break-word"><b>{{node.name}}</b></td>
           </tr>
           <tr>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -8,7 +8,7 @@
   <thead>
     <tr>
       <th>Status</th>
-      <th class="default">Hostname</th>
+      <th class="default">Certname</th>
       <th class="date default-sort">Catalog</th>
       <th class="date">Report</th>
       <th>&nbsp;</th>

--- a/puppetboard/templates/report.html
+++ b/puppetboard/templates/report.html
@@ -4,7 +4,7 @@
 <table class='ui basic table'>
   <thead>
     <tr>
-      <th>Hostname</th>
+      <th>Certname</th>
       <th>Configuration version</th>
       <th>Start time</th>
       <th>End time</th>


### PR DESCRIPTION
Certain column headers were referring to a node's certname as its
hostname. This commit corrects that by renaming the column headers.

If the intention was to display the hostnames instead of the certnames then please close this PR and I'll create a new one.