### PR TITLE
puppetboard/templates/metrics.html: Added searchability to the Metrics list

### DIFF
--- a/puppetboard/templates/metrics.html
+++ b/puppetboard/templates/metrics.html
@@ -1,9 +1,14 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h1>Metrics</h1>
-<ul>
+<div class="ui fluid icon input hide" style="margin-bottom:20px">
+  <input autofocus="autofocus" class="filter-list" placeholder="Type here to filter...">
+</div>
+<ul class="ui list searchable">
   {% for metric in metrics %}
-  <li><a href="{{url_for('metric', env=current_env, metric=metric)}}">{{metric}}</li>
+  <li>
+    <a href="{{url_for('metric', env=current_env, metric=metric)}}">{{metric}}</a>
+  </li>
   {% endfor %}
 </ul>
 {% endblock content %}


### PR DESCRIPTION
This resolves #297

Adding a search bar to the Metrics page to allow the user to filter the list
items to only show what the user wants.