### PR TITLE
radiator column width to percent

### DIFF
--- a/puppetboard/static/css/radiator.css
+++ b/puppetboard/static/css/radiator.css
@@ -39,4 +39,4 @@ body.radiator_controller table.node_summary tr td .percent {color:#000;position:
 body.radiator_controller table.node_summary tr td .percent span {margin-left:0.1em;}
 body.radiator_controller table.node_summary tr td .label {position:relative;height:100%;}
 body.radiator_controller table.node_summary tr td .label span {margin-left:0.1em;}
-body.radiator_controller table.node_summary tr td .count {text-align:right;width:1.75em;display:inline-block;font-weight:bold;margin-top:-0.12em;}
+body.radiator_controller table.node_summary tr td .count {text-align:right;width:100%;display:inline-block;font-weight:bold;margin-top:-0.12em;}


### PR DESCRIPTION
When using more than 1000 nodes>
![clipping](https://cloud.githubusercontent.com/assets/4910513/20850265/880b864e-b897-11e6-8b68-49f9e17d8a75.png)
The count values get clipped on all rows

But setting to 100% width produces the following:
![100_percent](https://cloud.githubusercontent.com/assets/4910513/20850266/880cf40c-b897-11e6-8d6f-3dc430380b9b.png)

