### PR TITLE
Commonmark version

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -27,6 +27,7 @@ from puppetboard.utils import (
 from puppetboard.dailychart import get_daily_reports_chart
 
 import werkzeug.exceptions as ex
+import CommonMark
 
 from . import __version__
 
@@ -606,7 +607,6 @@ def report(env, node_name, report_id):
     except StopIteration:
         abort(404)
 
-    import CommonMark
     report.version = CommonMark.commonmark(report.version)
 
     return render_template(

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -606,6 +606,9 @@ def report(env, node_name, report_id):
     except StopIteration:
         abort(404)
 
+    import CommonMark
+    report.version = CommonMark.commonmark(report.version)
+
     return render_template(
         'report.html',
         report=report,

--- a/puppetboard/templates/report.html
+++ b/puppetboard/templates/report.html
@@ -14,7 +14,7 @@
     <tr>
       <td><a href="{{url_for('node', env=current_env, node_name=report.node)}}">{{ report.node }}</a></td>
       <td>
-        {{report.version}}
+        {{report.version|safe}}
       </td>
       <td rel="utctimestamp">
         {{report.start}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Werkzeug >=0.12.1
 itsdangerous >=0.23
 pypuppetdb >=0.3.2
 requests >=2.13.0
+CommonMark==0.7.2


### PR DESCRIPTION
This allows to use markdown in `config_version`. I use this to make clickable links, e.g. if the config_version is:

```
[fix foo.wrk.lsn to hello.wrk.lsn](https://git.example.net/example/puppetmaster/commit/b4a9a6aaa606846ddkufk10e8ebc6feeb6358e55)
```

it will render it as a link with the commit message as text, and linking to the commit page.