### PR TITLE
Use puppetdb as PUPPETDB_HOST on Docker

### DIFF
--- a/puppetboard/docker_settings.py
+++ b/puppetboard/docker_settings.py
@@ -1,6 +1,6 @@
 import os
 
-PUPPETDB_HOST = os.getenv('PUPPETDB_HOST', 'localhost')
+PUPPETDB_HOST = os.getenv('PUPPETDB_HOST', 'puppetdb')
 PUPPETDB_PORT = int(os.getenv('PUPPETDB_PORT', '8080'))
 # Since this is an env it will alwas be a string, we need
 # to conver that string to a bool

--- a/test/test_docker_settings.py
+++ b/test/test_docker_settings.py
@@ -25,7 +25,7 @@ class DockerTestCase(unittest.TestCase):
         reload(docker_settings)
 
     def test_default_host_port(self):
-        self.assertEqual(docker_settings.PUPPETDB_HOST, 'localhost')
+        self.assertEqual(docker_settings.PUPPETDB_HOST, 'puppetdb')
         self.assertEqual(docker_settings.PUPPETDB_PORT, 8080)
 
     def test_set_host_port(self):


### PR DESCRIPTION
This allows to plug and play a PuppetDB container (or use extra host)