### PR TITLE
Setup.py : zip_safe to permit static serve

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     description='Web frontend for PuppetDB',
     include_package_data=True,
     long_description='\n'.join((README, CHANGELOG)),
+    zip_safe=False,
     install_requires=[
         "Flask >= 0.10.1",
         "Flask-WTF >= 0.12, <= 0.13",


### PR DESCRIPTION
During setup (apache + wsgi), I got errors about templates ("File not found").

Found this parameter to solve it. It prevents pip/easy_install to zip python module (used by egg installation mode) in installation directory.