### PR TITLE
Add total and noop boxes on reports page.

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -537,7 +537,7 @@ def reports_ajax(env, node_name):
         if total is None:
             total = puppetdb.total
 
-        metrics[report.hash_] = {'resources': {}, 'events': {}}
+        metrics[report.hash_] = {}
         for m in report.metrics:
             if m['category'] not in metrics[report.hash_]:
                 metrics[report.hash_][m['category']] = {}

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -534,21 +534,20 @@ def reports_ajax(env, node_name):
     report_event_counts = {}
     # Create a map from the metrics data to what the templates
     # use to express the data.
-    report_map = {
-        'success': 'successes',
-        'failure': 'failures',
-        'skipped': 'skips',
-        'noops': 'noop'
-    }
+    events_metrics = ['success', 'failure', 'noop']
+    resources_metrics = ['total', 'skipped']
     for report in reports_events:
         if total is None:
             total = puppetdb.total
 
-        report_counts = {'successes': 0, 'failures': 0, 'skips': 0}
-        for metrics in report.metrics:
-            if 'name' in metrics and metrics['name'] in report_map:
-                key_name = report_map[metrics['name']]
-                report_counts[key_name] = metrics['value']
+        report_counts = {}
+        for metric in report.metrics:
+            if ('category' in metric and metric['category'] == 'events' and
+               'name' in metric and metric['name'] in events_metrics):
+                report_counts[metric['name']] = metric['value']
+            if ('category' in metric and metric['category'] == 'resources' and
+               'name' in metric and metric['name'] in resources_metrics):
+                report_counts[metric['name']] = metric['value']
 
         report_event_counts[report.hash_] = report_counts
 

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -18,6 +18,11 @@ LOGLEVEL = 'info'
 NORMAL_TABLE_COUNT = 100
 LITTLE_TABLE_COUNT = 10
 TABLE_COUNT_SELECTOR = [10, 20, 50, 100, 500]
+DISPLAYED_METRICS = ['resources.total',
+                     'events.failure',
+                     'events.success',
+                     'resources.skipped',
+                     'events.noop']
 OFFLINE_MODE = False
 ENABLE_CATALOG = False
 OVERVIEW_FILTER = None

--- a/puppetboard/docker_settings.py
+++ b/puppetboard/docker_settings.py
@@ -33,6 +33,13 @@ TABLE_COUNT_DEF = "10,20,50,100,500"
 TABLE_COUNT_SELECTOR = [int(x) for x in os.getenv('TABLE_COUNT_SELECTOR',
                                                   TABLE_COUNT_DEF).split(',')]
 
+DISP_METR_DEF = ','.join(['resources.total', 'events.failure',
+                          'events.success', 'resources.skipped',
+                          'events.noop'])
+
+DISPLAYED_METRICS = [x.strip() for x in os.getenv('DISPLAYED_METRICS',
+                                                  DISP_METR_DEF).split(',')]
+
 OFFLINE_MODE = bool(os.getenv('OFFLINE_MODE', 'False').upper() == 'TRUE')
 ENABLE_CATALOG = bool(os.getenv('ENABLE_CATALOG', 'False').upper() == 'TRUE')
 OVERVIEW_FILTER = os.getenv('OVERVIEW_FILTER', None)
@@ -45,7 +52,6 @@ GRAPH_FACTS_DEFAULT = ','.join(['architecture', 'clientversion', 'domain',
 
 GRAPH_FACTS = [x.strip() for x in os.getenv('GRAPH_FACTS',
                                             GRAPH_FACTS_DEFAULT).split(',')]
-
 
 GRAPH_TYPE = os.getenv('GRAPH_TYPE', 'pie')
 

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -72,6 +72,14 @@ h1.ui.header.no-margin-bottom {
   background-color: #DB843D;
 }
 
+.ui.header.total {
+  color: #989898;
+}
+
+.ui.label.total {
+  background-color: #989898;
+}
+
 .ui.label.unchanged {
   background-color: #89A54E;
 }

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -44,7 +44,7 @@ h1.ui.header.no-margin-bottom {
   color: #AA4643;
 }
 
-.ui.label.failed {
+.ui.label.failed, .ui.label.events.failure {
   background-color: #AA4643;
 }
 
@@ -52,7 +52,7 @@ h1.ui.header.no-margin-bottom {
   color: #4572A7;
 }
 
-.ui.label.changed {
+.ui.label.changed, .ui.label.events.success {
   background-color: #4572A7;
 }
 
@@ -68,15 +68,11 @@ h1.ui.header.no-margin-bottom {
   color: #DB843D;
 }
 
-.ui.label.noop {
+.ui.label.noop, .ui.label.events.noop {
   background-color: #DB843D;
 }
 
-.ui.header.total {
-  color: #989898;
-}
-
-.ui.label.total {
+.ui.label.resources.total {
   background-color: #989898;
 }
 
@@ -88,7 +84,7 @@ h1.ui.header.no-margin-bottom {
   color: orange;
 }
 
-.ui.label.skipped {
+.ui.label.skipped, .ui.label.resources.skipped {
   background-color: orange;
 }
 

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -62,11 +62,11 @@
   {% if status == 'unreported' %}
     <span class="ui label status"> {{ unreported_time|upper }} </span>
   {% else %}
-    <span title="Total resources" class="ui small count label{% if metrics.resources.total %} total">{{ metrics.resources.total }}{% else %}">0{% endif%}</span>
-    <span title="Failure events" class="ui small count label{% if metrics.events.failure %} failed">{{ metrics.events.failure }}{% else %}">0{% endif%}</span>
-    <span title="Success events" class="ui small count label{% if metrics.events.success %} changed">{{ metrics.events.success }}{% else %}">0{% endif%}</span>
-    <span title="Skipped resources" class="ui small count label{% if metrics.resources.skipped %} skipped">{{ metrics.resources.skipped }}{% else %}">0{% endif%}</span>
-    <span title="Noop events" class="ui small count label{% if metrics.events.noop %} noop">{{ metrics.events.noop }}{% else %}">0{% endif%}</span>
+    {% for metric in config.DISPLAYED_METRICS %}
+      {% set path = metric.split('.') %}
+      {% set title = ' '.join(path) %}
+      <span title="{{ title }}" class="ui small count label{% if metrics[path[0]] and metrics[path[0]][path[1]] %} {{ title }}">{{ "%.2g"|format(metrics[path[0]][path[1]]) }}{% else %}">0{% endif%}</span>
+    {% endfor %}
   {% endif %}
 {%- endmacro %}
 

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -57,16 +57,16 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro report_status(caller, status, node_name, events, current_env, unreported_time=False, report_hash=False) -%}
+{% macro report_status(caller, status, node_name, metrics, current_env, unreported_time=False, report_hash=False) -%}
   <a class="ui {{status}} label status" href="{{url_for('report', env=current_env, node_name=node_name, report_id=report_hash)}}">{{ status|upper }}</a>
   {% if status == 'unreported' %}
     <span class="ui label status"> {{ unreported_time|upper }} </span>
   {% else %}
-    <span title="Total resources" class="ui small count label{% if events['total'] %} total">{{events['total']}}{% else %}">0{% endif%}</span>
-    <span title="Failure events" class="ui small count label{% if events['failure'] %} failed">{{events['failure']}}{% else %}">0{% endif%}</span>
-    <span title="Success events" class="ui small count label{% if events['success'] %} changed">{{events['success']}}{% else %}">0{% endif%}</span>
-    <span title="Skip events" class="ui small count label{% if events['skipped'] %} skipped">{{events['skipped']}}{% else %}">0{% endif%}</span>
-    <span title="Noop resources" class="ui small count label{% if events['noop'] %} noop">{{events['noop']}}{% else %}">0{% endif%}</span>
+    <span title="Total resources" class="ui small count label{% if metrics.resources.total %} total">{{ metrics.resources.total }}{% else %}">0{% endif%}</span>
+    <span title="Failure events" class="ui small count label{% if metrics.events.failure %} failed">{{ metrics.events.failure }}{% else %}">0{% endif%}</span>
+    <span title="Success events" class="ui small count label{% if metrics.events.success %} changed">{{ metrics.events.success }}{% else %}">0{% endif%}</span>
+    <span title="Skipped resources" class="ui small count label{% if metrics.resources.skipped %} skipped">{{ metrics.resources.skipped }}{% else %}">0{% endif%}</span>
+    <span title="Noop events" class="ui small count label{% if metrics.events.noop %} noop">{{ metrics.events.noop }}{% else %}">0{% endif%}</span>
   {% endif %}
 {%- endmacro %}
 

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -57,6 +57,19 @@
   {% endif %}
 {%- endmacro %}
 
+{% macro report_status(caller, status, node_name, events, current_env, unreported_time=False, report_hash=False) -%}
+  <a class="ui {{status}} label status" href="{{url_for('report', env=current_env, node_name=node_name, report_id=report_hash)}}">{{ status|upper }}</a>
+  {% if status == 'unreported' %}
+    <span class="ui label status"> {{ unreported_time|upper }} </span>
+  {% else %}
+    <span title="Total resources" class="ui small count label{% if events['total'] %} total">{{events['total']}}{% else %}">0{% endif%}</span>
+    <span title="Failure events" class="ui small count label{% if events['failure'] %} failed">{{events['failure']}}{% else %}">0{% endif%}</span>
+    <span title="Success events" class="ui small count label{% if events['success'] %} changed">{{events['success']}}{% else %}">0{% endif%}</span>
+    <span title="Skip events" class="ui small count label{% if events['skipped'] %} skipped">{{events['skipped']}}{% else %}">0{% endif%}</span>
+    <span title="Noop resources" class="ui small count label{% if events['noop'] %} noop">{{events['noop']}}{% else %}">0{% endif%}</span>
+  {% endif %}
+{%- endmacro %}
+
 {% macro datatable_init(table_html_id, ajax_url, default_length, length_selector, extra_options=None) -%}
   // Init datatable
   $.fn.dataTable.ext.errMode = 'throw';

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -65,7 +65,17 @@
     {% for metric in config.DISPLAYED_METRICS %}
       {% set path = metric.split('.') %}
       {% set title = ' '.join(path) %}
-      <span title="{{ title }}" class="ui small count label{% if metrics[path[0]] and metrics[path[0]][path[1]] %} {{ title }}">{{ "%.2g"|format(metrics[path[0]][path[1]]) }}{% else %}">0{% endif%}</span>
+      {% if metrics[path[0]] and metrics[path[0]][path[1]] %}
+      {% set value = metrics[path[0]][path[1]] %}
+      {% if value != 0 and value|int != value %}
+        {% set format_str = '%.2f' %}
+      {% else %}
+        {% set format_str = '%s' %}
+      {% endif %}
+        <span title="{{ title }}" class="ui small count label {{ title }}">{{ format_str|format(value) }}</span>
+      {% else %}
+        <span title="{{ title }}" class="ui small count label">0</span>
+      {% endif%}
     {% endfor %}
   {% endif %}
 {%- endmacro %}

--- a/puppetboard/templates/reports.json.tpl
+++ b/puppetboard/templates/reports.json.tpl
@@ -15,7 +15,7 @@
             "<span rel=\"utctimestamp\">{{ report[column.attr] }}</span>"
           {%- elif column.type == 'status' -%}
             {% filter jsonprint -%}
-              {{ macros.status_counts(status=report.status, node_name=report.node, events=report_event_counts[report.hash_], report_hash=report.hash_, current_env=current_env) }}
+              {{ macros.report_status(status=report.status, node_name=report.node, events=report_event_counts[report.hash_], report_hash=report.hash_, current_env=current_env) }}
             {%- endfilter %}
           {%- elif column.type == 'node' -%}
             {% filter jsonprint %}<a href="{{url_for('node', env=current_env, node_name=report.node)}}">{{ report.node }}</a>{% endfilter %}

--- a/puppetboard/templates/reports.json.tpl
+++ b/puppetboard/templates/reports.json.tpl
@@ -15,7 +15,7 @@
             "<span rel=\"utctimestamp\">{{ report[column.attr] }}</span>"
           {%- elif column.type == 'status' -%}
             {% filter jsonprint -%}
-              {{ macros.report_status(status=report.status, node_name=report.node, events=report_event_counts[report.hash_], report_hash=report.hash_, current_env=current_env) }}
+              {{ macros.report_status(status=report.status, node_name=report.node, metrics=metrics[report.hash_], report_hash=report.hash_, current_env=current_env) }}
             {%- endfilter %}
           {%- elif column.type == 'node' -%}
             {% filter jsonprint %}<a href="{{url_for('node', env=current_env, node_name=report.node)}}">{{ report.node }}</a>{% endfilter %}

--- a/test/test_docker_settings.py
+++ b/test/test_docker_settings.py
@@ -116,3 +116,11 @@ def test_env_table_selector(cleanUpEnv):
     os.environ['TABLE_COUNT_SELECTOR'] = '5,15,25'
     reload(docker_settings)
     assert [5, 15, 25] == docker_settings.TABLE_COUNT_SELECTOR
+
+
+def test_env_column_options(cleanUpEnv):
+    os.environ['DISPLAYED_METRICS'] = 'resources.total, events.failure'
+
+    reload(docker_settings)
+    assert ['resources.total',
+            'events.failure'] == docker_settings.DISPLAYED_METRICS


### PR DESCRIPTION
Sum up 'noop' and 'skipped' resources from reports into displayed "skips" value. Particularly relevant when doing 'noop' runs on nodes in order to identify how far the node is from baseline.

'noop' resources may also be explicitly declared in catalogs (even in normal run). In this case, we are losing a bit of information. But, I don't know what is the typical use case of noop resource. This use case may match our interface behavior.