### PR TITLE
Support for latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,25 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+env:
+  - PINNED=TRUE
+  - PINNED=FALSE
+
+matrix:
+  allow_failures:
+    - python: 2.6
+      env: PINNED=FALSE
+    - python: 2.7
+      env: PINNED=FALSE
+    - python: 3.5
+      env: PINNED=FALSE
+    - python: 3.6
+      env: PINNED=FALSE
+
 install:
+  - if [ "${PINNED}" == "FALSE" ]; then python scripts/unpin.py; fi
   - pip install -r requirements.txt
-  - pip install -r requirements-test.txt
+  - pip install -U -r requirements-test.txt
   - pip install -q coverage coveralls --use-wheel
 script:
   - py.test --cov=puppetboard --pep8  -v

--- a/dev.py
+++ b/dev.py
@@ -3,11 +3,7 @@ from __future__ import absolute_import
 import os
 import subprocess
 
-if 'PUPPETBOARD_SETTINGS' not in os.environ:
-    os.environ['PUPPETBOARD_SETTINGS'] = os.path.join(
-        os.getcwd(), 'settings.py'
-    )
-
+# Set PUPPETBOARD_SETTINGS to your settings.py
 from puppetboard.app import app
 
 if __name__ == '__main__':

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -17,6 +17,7 @@ from flask import (
 )
 
 from pypuppetdb import connect
+from pypuppetdb.errors import EmptyResponseError
 from pypuppetdb.QueryBuilder import *
 
 from puppetboard.forms import (CatalogForm, QueryForm)
@@ -115,10 +116,14 @@ class NoContent(ex.HTTPException):
 
 abort.mapping[204] = NoContent
 
-
-@app.errorhandler(204)
-def no_content(e):
-    return '', 204
+try:
+    @app.errorhandler(204)
+    def no_content(e):
+        return '', 204
+except KeyError:
+    @app.errorhandler(EmptyResponseError)
+    def no_content(e):
+        return '', 204
 
 
 @app.errorhandler(400)

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -203,7 +203,7 @@ def index(env):
         num_nodes_query.add_field(FunctionOperator('count'))
         num_nodes_query.add_query(query)
 
-        if app.config['OVERVIEW_FILTER'] != None:
+        if app.config['OVERVIEW_FILTER'] is not None:
             query.add(app.config['OVERVIEW_FILTER'])
 
         num_resources_query = ExtractOperator()

--- a/puppetboard/templates/reports.json.tpl
+++ b/puppetboard/templates/reports.json.tpl
@@ -4,13 +4,13 @@
   "recordsTotal": {{total}},
   "recordsFiltered": {{total_filtered}},
   "data": [
+    {%- set report_flag = false -%}
     {% for report in reports -%}
-      {%- if report_flag %},{%- endif %}
-      {%- set report_flag = True -%}
+      {%- if not loop.first %},{%- endif -%}
       [
+        {%- set column_flag = false -%}
         {%- for column in columns -%}
-          {%- if column_flag %},{%- endif -%}
-          {%- set column_flag = True -%}
+          {%- if not loop.first %},{%- endif -%}
           {%- if column.type == 'datetime' -%}
             "<span rel=\"utctimestamp\">{{ report[column.attr] }}</span>"
           {%- elif column.type == 'status' -%}

--- a/scripts/unpin.py
+++ b/scripts/unpin.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import glob
+import re
+try:
+    import future.utils
+except:
+    pass
+
+
+for req_file in glob.glob('requirements*.txt'):
+    new_data = []
+    with open(req_file, 'r') as fp:
+        data = fp.readlines()
+        for line in data:
+            new_data.append(re.sub(r'==\d+(\.\d+){0,3}\s+$', '\n', line))
+
+    with open(req_file, 'w') as fp:
+        fp.writelines(new_data)


### PR DESCRIPTION
Adding "Unpinned" upgrade checks on packages that puppetboard depends on.  These unpinned checks are allowed to fail, but will identify when a new release of a package will break puppetboard.

Adding fixes for newer Flask, Jinja2 and pep8 issues.  Fixing #345 