### PR TITLE
Unbreak boolean facts graph

### DIFF
--- a/puppetboard/templates/fact.html
+++ b/puppetboard/templates/fact.html
@@ -7,7 +7,7 @@ var chart = null;
 var data = [
 {% for fact in facts|groupby('value') %}
   {
-  label: '{{ fact.grouper.replace("\n", " ") }}',
+  label: '{{ ("%s" % fact.grouper).replace("\n", " ") }}',
   value: {{ fact.list|length }}
   },
 {% endfor %}


### PR DESCRIPTION
When graphing boolean facts, a `UndefinedError: 'bool object' has no attribute 'replace'` exception is raised (#302).

This patch attempts to turn whatever is going to be displayed to a string.