### PR TITLE
Made list of endpoints displayed configurable.

### DIFF
--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -43,3 +43,12 @@ INVENTORY_FACTS = [('Hostname', 'fqdn'),
 REFRESH_RATE = 30
 DAILY_REPORTS_CHART_ENABLED = True
 DAILY_REPORTS_CHART_DAYS = 8
+ENDPOINTS = [('index', 'Overview'),
+             ('nodes', 'Nodes'),
+             ('facts', 'Facts'),
+             ('reports', 'Reports'),
+             ('metrics', 'Metrics'),
+             ('inventory', 'Inventory'),
+             ('catalogs', 'Catalogs'),
+             ('radiator', 'Radiator'),
+             ('query', 'Query'), ]

--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -63,17 +63,7 @@
       <div class="title item">
         Puppetboard
       </div>
-      {%- for endpoint, caption in [
-      ('index', 'Overview'),
-      ('nodes', 'Nodes'),
-      ('facts', 'Facts'),
-      ('reports', 'Reports'),
-      ('metrics', 'Metrics'),
-      ('inventory', 'Inventory'),
-      ('catalogs', 'Catalogs'),
-      ('radiator', 'Radiator'),
-      ('query', 'Query'),
-      ] %}
+      {%- for endpoint, caption in config.ENDPOINTS %}
       <a {% if endpoint == request.endpoint %} class="active item" {% else %} class="item" {% endif %}
         href="{{ url_for(endpoint, env=current_env) }}">{{ caption }}</a>
       {%- endfor %}


### PR DESCRIPTION
Pulled the hard-coded list of the endoints out of templates/layout.html
thus making it possible to hide certain unwanted endpoints from the main
menu by simply editing the config. New ENDPOINTS setting has been added.