### PR TITLE
Fix formatvalue for list of dicts

### DIFF
--- a/puppetboard/utils.py
+++ b/puppetboard/utils.py
@@ -51,7 +51,7 @@ def formatvalue(value):
     if isinstance(value, str):
         return value
     elif isinstance(value, list):
-        return ", ".join(value)
+        return ", ".join(map(formatvalue, value))
     elif isinstance(value, dict):
         ret = ""
         for k in value:


### PR DESCRIPTION
formatvalue fails for list of dicts with:

> TypeError: sequence item 0: expected string or Unicode, dict found

example: `formatvalue([{}])`