### PR TITLE
Bounded the latest version of Werkzeug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-env:
-  - PINNED=TRUE
-  - PINNED=FALSE
-
-matrix:
-  allow_failures:
-    - python: 2.6
-      env: PINNED=FALSE
-    - python: 2.7
-      env: PINNED=FALSE
-    - python: 3.5
-      env: PINNED=FALSE
-    - python: 3.6
-      env: PINNED=FALSE
 
 install:
-  - if [ "${PINNED}" == "FALSE" ]; then python scripts/unpin.py; fi
   - pip install -r requirements.txt
   - pip install -U -r requirements-test.txt
   - pip install -q coverage coveralls --use-wheel

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Flask >= 0.10.1",
         "Flask-WTF >= 0.12, <= 0.13",
         "WTForms >= 2.0, < 3.0",
+        "Werkzeug >=0.7, <= 0.11.5",
         "pypuppetdb >= 0.3.0, < 0.4.0",
     ],
     keywords="puppet puppetdb puppetboard",


### PR DESCRIPTION
Cannot install the least version of Werkzeug, this causes issues with the abort handling that was introduced and then removed.

This is in preparation of a release 0.2.2