### PR TITLE
Fix dailychart.js when using non-root location

### DIFF
--- a/puppetboard/static/js/dailychart.js
+++ b/puppetboard/static/js/dailychart.js
@@ -1,6 +1,6 @@
 jQuery(function ($) {
   function generateChart(el) {
-    var url = "/daily_reports_chart.json";
+    var url = "daily_reports_chart.json";
     var certname = $(el).attr('data-certname');
     if (typeof certname !== typeof undefined && certname !== false) {
       url = url + "?certname=" + certname;


### PR DESCRIPTION
When puppetboard is being run from a directory instead of the root of the domain, the daily chart will not work as it tries to load the data from the root. This change makes it load the data from the current working URL, instead of forcing root.