### PR TITLE
Adding Docker puppet version tagging

### DIFF
--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+version=$(git describe HEAD --abbrev=4)
+
+cat << EOF > puppetboard/version.py
+#
+# Puppetboard version module
+#
+__version__ = '${version}'
+EOF
+


### PR DESCRIPTION
Using new cloud.docker to build containers.  During the prebuild set the version that was checked out and set the __version__ value.