### PR TITLE
Rework "nodes" with datatables.

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -395,7 +395,7 @@ def nodes_ajax(env):
 
     status_query = OrOperator()
     for status_arg in status_args:
-        if status_arg not in ['', '*']:
+        if status_arg not in ['', '*', 'none']:
             arg_query = get_node_status_query(status_arg)
             if arg_query:
                 status_query.add(arg_query)

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -9,27 +9,27 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro report_status(caller, status, node_name, metrics, current_env, unreported_time=False, report_hash=False) -%}
-  <a class="ui {{status}} label status" href="{{url_for('report', env=current_env, node_name=node_name, report_id=report_hash)}}">{{ status|upper }}</a>
-  {% if status == 'unreported' %}
+{% macro report_status(caller, status, report, current_env, unreported_time=False) -%}
+  <a class="ui {{status}} label status" href="{{ url_for('report', env=current_env, node_name=report.node, report_id=report.hash_) }}">{{ status|upper }}</a>
+  {% if status == 'unreported' -%}
     <span class="ui label status"> {{ unreported_time|upper }} </span>
-  {% else %}
-    {% for metric in config.DISPLAYED_METRICS %}
-      {% set path = metric.split('.') %}
-      {% set title = ' '.join(path) %}
-      {% if metrics[path[0]] and metrics[path[0]][path[1]] %}
-      {% set value = metrics[path[0]][path[1]] %}
-      {% if value != 0 and value|int != value %}
-        {% set format_str = '%.2f' %}
-      {% else %}
-        {% set format_str = '%s' %}
-      {% endif %}
+  {% else -%}
+    {%- for metric in config.DISPLAYED_METRICS -%}
+      {%- set path = metric.split('.') -%}
+      {%- set title = ' '.join(path) -%}
+      {%- set value = report.metric(path[0], path[1]) -%}
+      {%- if value -%}
+        {%- if value != 0 and value|int != value -%}
+          {%- set format_str = '%.2f' -%}
+        {%- else -%}
+          {%- set format_str = '%s' -%}
+        {%- endif -%}
         <span title="{{ title }}" class="ui small count label {{ title }}">{{ format_str|format(value) }}</span>
-      {% else %}
+      {% else -%}
         <span title="{{ title }}" class="ui small count label">0</span>
-      {% endif%}
-    {% endfor %}
-  {% endif %}
+      {% endif -%}
+    {%- endfor -%}
+  {%- endif -%}
 {%- endmacro %}
 
 {% macro datatable_init(table_html_id, ajax_url, default_length, length_selector, extra_options=None) -%}

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -1,7 +1,7 @@
 {% macro status_counts(caller, status, node_name, events, current_env, unreported_time=False, report_hash=False) -%}
   <a class="ui {{status}} label status" href="{{url_for('report', env=current_env, node_name=node_name, report_id=report_hash)}}">{{ status|upper }}</a>
   {% if status == 'unreported' %}
-    <span class="ui label status"> {{ unreported_time|upper }} </span>
+    <span class="ui label status" rel="utctimestamp"> {{ unreported_time|upper }} </span>
   {% else %}
     {% if events['failures'] %}<span class="ui small count label failed">{{events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
     {% if events['successes'] %}<span class="ui small count label changed">{{events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -1,16 +1,53 @@
-{% macro status_counts(caller, status, node_name, events, current_env, unreported_time=False, report_hash=False) -%}
-  <a class="ui {{status}} label status" href="{{url_for('report', env=current_env, node_name=node_name, report_id=report_hash)}}">{{ status|upper }}</a>
-  {% if status == 'unreported' %}
-    <span class="ui label status" rel="utctimestamp"> {{ unreported_time|upper }} </span>
-  {% else %}
-    {% if events['failures'] %}<span class="ui small count label failed">{{events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
-    {% if events['successes'] %}<span class="ui small count label changed">{{events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
-    {% if events['skips'] %}<span class="ui small count label skipped">{{events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
-  {% endif %}
+{% macro facts_table(facts, current_env, autofocus=False, condensed=False, show_node=False, show_value=True, link_facts=False, margin_top=20, margin_bottom=20) -%}
+<div class="ui fluid icon input hide" style="margin-bottom:20px">
+  <input {% if autofocus %} autofocus="autofocus" {% endif %} class="filter-table" placeholder="Type here to filter...">
+</div>
+<table class="ui very basic {% if condensed %}very{% endif%} compact sortable table" style="table-layout: fixed;">
+  <thead>
+    <tr>
+      {% if show_node %}
+      <th>Node</th>
+      {% else %}
+      <th class="default-sort">Fact</th>
+      {% endif %}
+      {% if show_value %}
+      <th>Value</th>
+      {% endif %}
+    </tr>
+  </thead>
+  <tbody class="searchable">
+    {% for fact in facts %}
+    <tr>
+      {% if show_node %}
+        <td><a href="{{url_for('node', env=current_env, node_name=fact.node)}}">{{fact.node}}</a></td>
+      {% else %}
+        <td><a href="{{url_for('fact', env=current_env, fact=fact.name)}}">{{fact.name}}</a></td>
+      {% endif %}
+      {% if show_value %}
+      <td style="word-wrap:break-word">
+        {% if link_facts %}
+          {% if fact.value is mapping %}
+            <a href="{{url_for('fact_value', env=current_env, fact=fact.name, value=fact.value)}}"><pre>{{fact.value|jsonprint}}</pre></a>
+          {% else %}
+            <a href="{{url_for('fact_value', env=current_env, fact=fact.name, value=fact.value)}}">{{fact.value}}</a>
+          {% endif %}
+        {% else %}
+          {% if fact.value is mapping %}
+            <pre>{{fact.value|jsonprint}}</pre>
+          {% else %}
+            {{fact.value}}
+          {% endif %}
+        {% endif %}
+      </td>
+      {% endif %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {%- endmacro %}
 
 {% macro report_status(caller, status, report, current_env, unreported_time=False) -%}
-  <a class="ui {{status}} label status" href="{{ url_for('report', env=current_env, node_name=report.node, report_id=report.hash_) }}">{{ status|upper }}</a>
+  <a class="ui {{status}} label status"{% if report %} href="{{ url_for('report', env=current_env, node_name=report.node, report_id=report.hash_) }}{% endif %}">{{ status|upper }}</a>
   {% if status == 'unreported' -%}
     <span class="ui label status"> {{ unreported_time|upper }} </span>
   {% else -%}

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -60,15 +60,15 @@
     <div class="column">
     </div>
     <div class="column">
-      <h1 class="ui header darkblue no-margin-bottom">{{metrics['num_nodes']}}</h1>
+      <h1 class="ui header darkblue no-margin-bottom">{{stats['total']}}</h1>
       <span>Population</span>
     </div>
     <div class="column">
-      <h1 class="ui header darkblue no-margin-bottom">{{metrics['num_resources']}}</h1>
+      <h1 class="ui header darkblue no-margin-bottom">{{stats['num_resources']}}</h1>
       <span>Resources managed</span>
     </div>
     <div class="column">
-      <h1 class="ui header darkblue no-margin-bottom">{{metrics['avg_resources_node']}}</h1>
+      <h1 class="ui header darkblue no-margin-bottom">{{stats['avg_resources_node']}}</h1>
       <span>Avg. resources/node</span>
     </div>
   </div>
@@ -80,9 +80,9 @@
   <div class="ui divider"></div>
   <div class="one column row">
     <div class="column">
+      <h2 class="ui two">Latest nodes runs</h2>
       {% if nodes %}
-      <h2>Nodes status detail ({{nodes|length}})</h2>
-      <table class='ui sortable very compact very basic table'>
+      <table class='ui very compact very basic table'>
         <thead>
           <tr>
             <th class="five wide">Status</th>
@@ -96,11 +96,7 @@
           {% if node.status != 'unchanged' %}
           <tr>
             <td>
-              {% if node.latest_report_hash %}
-                {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env, report_hash=node.latest_report_hash)}}
-              {% else %}
-                {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env)}}
-              {% endif %}
+              {{ macros.report_status(status=node.status, report=node.report, unreported_time=node.unreported_time, current_env=current_env) }}
             </td>
             <td>
               <a href="{{url_for('node', env=current_env, node_name=node.name)}}">{{ node.name }}</a>
@@ -123,7 +119,6 @@
         </tbody>
       </table>
       {% else %}
-      <h2>Nodes status detail</h2>
       <div class="ui info message">
         Nothing seems to be changing.
       </div>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -1,56 +1,64 @@
 {% extends 'layout.html' %}
 {% import '_macros.html' as macros %}
 {% block content %}
-<div class="ui fluid icon input hide" style="margin-bottom:20px">
-  <input autofocus="autofocus" class="filter-table" placeholder="Type here to filter...">
-</div>
-<table class='ui very compact very basic sortable table'>
-  <thead>
-    <tr>
-      <th>Status</th>
-      <th class="default">Certname</th>
-      <th class="date default-sort">Catalog</th>
-      <th class="date">Report</th>
-      <th>&nbsp;</th>
-    </tr>
-  </thead>
-  <tbody class="searchable">
-    {% for node in nodes %}
-    <tr>
-      <td>
-        {% if node.latest_report_hash %}
-          {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env, report_hash=node.latest_report_hash)}}
-        {% else %}
-          {{macros.status_counts(status=node.status, node_name=node.name, events=node.events, unreported_time=node.unreported_time, current_env=current_env)}}
-        {% endif %}
-      </td>
-      <td><a href="{{url_for('node', env=current_env, node_name=node.name)}}">{{node.name}}</a></td>
-      <td><a rel="utctimestamp" href="{{url_for('catalog_node', env=current_env, node_name=node.name)}}">{{node.catalog_timestamp}}</a></td>
-      <td>
-        {% if node.report_timestamp %}
-          <a href="{{url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>
-        {% else %}
-          <i class="large darkblue ban icon"></i>
-        {% endif %}
-      </td>
-      <td>
-        {% if node.report_timestamp %}
-        <a title='Reports' href="{{url_for('reports', env=current_env, node_name=node.name)}}"><i class='large darkblue book icon'></i></a>
-        {% endif %}
-      </td>
-    </tr>
+<div class="ui wide grid">
+  <div class="wide row">
+    <div class="four wide column">
+      <div class="ui">Status</div>
+    </div>
+    {% for status in ['failed', 'changed', 'unchanged', 'noop', 'unreported'] %}
+      <div class="two wide column">
+        <div class="ui checked checkbox">
+          {% if status_pick is none or status_pick == status %}
+            <input id="{{ status }}" checked="" type="checkbox">
+          {% else %}
+            <input id="{{ status }}" type="checkbox">
+          {% endif %}
+          <label>{{ status|capitalize }}</label>
+        </div>
+      </div>
     {% endfor %}
-  </tbody>
-</table>
-<div class="ui dropdown" style="float:right;">
-  <div class="text">Filter By</div>
-  <i class="dropdown icon"></i>
-  <div class="menu">
-    <a class="item" href="{{url_for_field('status', 'failed')}}">Failed</a>
-    <a class="item" href="{{url_for_field('status', 'changed')}}">Changed</a>
-    <a class="item" href="{{url_for_field('status', 'unchanged')}}">Unchanged</a>
-    <a class="item" href="{{url_for_field('status', 'noop')}}">Noop</a>
-    <a class="item" href="{{url_for_field('status', 'unreported')}}">Unreported</a>
   </div>
 </div>
+<table id="nodes_table" class='ui very basic table stackable'>
+  <thead>
+    <tr>
+      {% for column in columns %}
+      <th>{{ column.name }}</th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+  </tbody>
+</table>
 {% endblock content %}
+{% block onload_script %}
+{% macro extra_options(caller) %}
+  // No initial loading
+  "deferLoading": true,
+{% endmacro %}
+  {{ macros.datatable_init(table_html_id="nodes_table", ajax_url=url_for('nodes_ajax', env=current_env), default_length=config.NORMAL_TABLE_COUNT, length_selector=config.TABLE_COUNT_SELECTOR, extra_options=extra_options) }}
+
+  // Event listener for status filters
+  function status_filter_change(){
+    var sum = '';
+    var failed = $('#failed').prop('checked');
+    var changed = $('#changed').prop('checked');
+    var unchanged = $('#unchanged').prop('checked');
+    var noop = $('#noop').prop('checked');
+    var unreported = $('#unreported').prop('checked');
+    if ( failed && changed && unchanged && noop && unreported) { sum = '*'; }
+    else if (!(failed || changed || unchanged || noop || unreported)) { sum = 'none'; }
+    else {
+      if (failed) { sum += 'failed|'; }
+      if (changed) { sum += 'changed|'; }
+      if (unchanged) { sum += 'unchanged|'; }
+      if (noop) { sum += 'noop|'; }
+      if (unreported) { sum += 'unreported|'; }
+    }
+    table.column(1).search(sum).draw();
+  }
+  $('#failed, #changed, #unchanged, #noop, #unreported').change(status_filter_change);
+  // Call at init - fix page reload behavior
+  status_filter_change();
+{% endblock onload_script %}

--- a/puppetboard/templates/nodes.json.tpl
+++ b/puppetboard/templates/nodes.json.tpl
@@ -1,0 +1,45 @@
+{%- import '_macros.html' as macros -%}
+{
+  "draw": {{draw}},
+  "recordsTotal": {{total}},
+  "recordsFiltered": {{total_filtered}},
+  "data": [
+    {% for node in nodes -%}
+      {%- if flag %},{%- endif %}
+      {%- set flag = True -%}
+      [
+        {%- for column in columns -%}
+          {%- if column_flag %},{%- endif -%}
+          {%- set column_flag = True -%}
+          {%- if column.type == 'datetime' -%}
+            {%- if column.name == "Catalog" -%}
+              "<a rel=\"utctimestamp\" href=\"{{ url_for('catalog_node', env=current_env, node_name=node.name) }}\">{{node.catalog_timestamp}}</a>"
+            {%- elif column.name == "Report" -%}
+              {%- if node.report_timestamp -%}
+                "<a href=\"{{ url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash) }}\" rel=\"utctimestamp\">{{ node.report_timestamp }}</a>"
+              {%- else -%}
+                "<i class=\"large darkblue ban icon\"></i>"
+              {%- endif -%}
+            {%- elif column.name == "" -%}
+              {% if node.report_timestamp %}
+                "<a title=\"Reports\" href=\"{{ url_for('reports', env=current_env, node_name=node.name) }}\"><i class=\"large darkblue book icon\"></i></a>"
+              {%- else -%}
+                ""
+              {% endif %}
+            {%- else -%}
+              "{{ report[column.attr] }}"
+            {%- endif -%}
+          {%- elif column.type == 'status' -%}
+            {% filter jsonprint -%}
+                {{ macros.report_status(status=node.status, report=node.report, unreported_time=node.unreported_time, current_env=current_env) }}
+            {%- endfilter %}
+          {%- elif column.type == 'node' -%}
+            {% filter jsonprint %}<a href="{{ url_for('node', env=current_env, node_name=node.name) }}">{{ node.name }}</a>{% endfilter %}
+          {%- else -%}
+            {{ report[column.attr] | jsonprint }}
+          {%- endif -%}
+        {%- endfor -%}
+      ]
+    {% endfor %}
+  ]
+}

--- a/puppetboard/templates/nodes.json.tpl
+++ b/puppetboard/templates/nodes.json.tpl
@@ -5,12 +5,10 @@
   "recordsFiltered": {{total_filtered}},
   "data": [
     {% for node in nodes -%}
-      {%- if flag %},{%- endif %}
-      {%- set flag = True -%}
+      {%- if not loop.first %},{%- endif -%}
       [
         {%- for column in columns -%}
-          {%- if column_flag %},{%- endif -%}
-          {%- set column_flag = True -%}
+          {%- if not loop.first %},{%- endif -%}
           {%- if column.type == 'datetime' -%}
             {%- if column.name == "Catalog" -%}
               "<a rel=\"utctimestamp\" href=\"{{ url_for('catalog_node', env=current_env, node_name=node.name) }}\">{{node.catalog_timestamp}}</a>"

--- a/puppetboard/templates/radiator.html
+++ b/puppetboard/templates/radiator.html
@@ -92,7 +92,7 @@
         </tr>
         <tr class='total'>
             <td class='count_column'>
-                <span class='count'>{{total}}</span>
+                <span class='count'>{{stats['total']}}</span>
             </td>
             <td>
                 <div>

--- a/puppetboard/templates/reports.json.tpl
+++ b/puppetboard/templates/reports.json.tpl
@@ -15,7 +15,7 @@
             "<span rel=\"utctimestamp\">{{ report[column.attr] }}</span>"
           {%- elif column.type == 'status' -%}
             {% filter jsonprint -%}
-              {{ macros.report_status(status=report.status, node_name=report.node, metrics=metrics[report.hash_], report_hash=report.hash_, current_env=current_env) }}
+              {{ macros.report_status(status=report.status, report=report, current_env=current_env) }}
             {%- endfilter %}
           {%- elif column.type == 'node' -%}
             {% filter jsonprint %}<a href="{{url_for('node', env=current_env, node_name=report.node)}}">{{ report.node }}</a>{% endfilter %}

--- a/puppetboard/templates/reports.json.tpl
+++ b/puppetboard/templates/reports.json.tpl
@@ -4,11 +4,9 @@
   "recordsTotal": {{total}},
   "recordsFiltered": {{total_filtered}},
   "data": [
-    {%- set report_flag = false -%}
     {% for report in reports -%}
       {%- if not loop.first %},{%- endif -%}
       [
-        {%- set column_flag = false -%}
         {%- for column in columns -%}
           {%- if not loop.first %},{%- endif -%}
           {%- if column.type == 'datetime' -%}

--- a/puppetboard/utils.py
+++ b/puppetboard/utils.py
@@ -34,7 +34,7 @@ def get_db_version(puppetdb):
         version = puppetdb.current_version()
         (major, minor, build) = [int(x) for x in version.split('.')]
         ver = (major, minor, build)
-        log.info("PuppetDB Version %d.%d.%d" % (major, minor, build))
+        log.debug("PuppetDB Version %d.%d.%d" % (major, minor, build))
     except ValueError as e:
         log.error("Unable to determine version from string: '%s'" % version)
         ver = (4, 2, 0)


### PR DESCRIPTION
This PR will need voxpupuli/pypuppetdb#116 to work.

Worked on this for personal use. Fine on my side, but may need improvements or clarity.

A lot of lines refers to puppetdb 3.X inability to provide a consistent "Node" status on "noop" runs. This might be simplified by dropping 3.X support. By the meantime, this PR contains compatibility functions.

For information, this also include a fix for @phybros latest input (report.metrics == None).