### PR TITLE
Handle attribute error on path.

### DIFF
--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -35,6 +35,7 @@
 {% macro datatable_init(table_html_id, ajax_url, default_length, length_selector, extra_options=None) -%}
   // Init datatable
   $.fn.dataTable.ext.errMode = 'throw';
+
   var table = $('#{{ table_html_id }}').DataTable({
     // Permit flow auto-readjust (responsive)
     "autoWidth": false,
@@ -58,6 +59,11 @@
     // Custom options
     {% if extra_options %}{% call extra_options() %}Callback to parent defined options{% endcall %}{% endif %}
   });
+
+  table.on('error', function ( e, settings, json ) {
+    table.clear().draw();
+    $('#facts_table_processing').hide(); })
+
 
   table.on('draw.dt', function(){
     $('#{{ table_html_id }} [rel=utctimestamp]').each(

--- a/puppetboard/templates/fact.html
+++ b/puppetboard/templates/fact.html
@@ -31,7 +31,7 @@ table.on('xhr', function(e, settings, json){
 {% if render_graph %}
 <div id="factChart" width="300" height="300"></div>
 {% endif %}
-<h1>{{ fact }}{% if value %}/{{ value }}{% endif %}</h1>
+<h1>{{ fact }}{% if value_safe %} : {{ value_safe }}{% endif %}</h1>
 <table id="facts_table" class='ui fixed very basic compact table stackable'>
   <thead>
     <tr>


### PR DESCRIPTION
Encode paths properly so that they do not cause issues when trying to pass them in as fact search paths.

When getting a 404 or an error from the puppet board Ajax call allow datable to reset and return and error that shows no data and hide the processing box.

Fix #385.

