### PR TITLE
Remove date classes from nodes page

### DIFF
--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -87,7 +87,7 @@
           <tr>
             <th class="five wide">Status</th>
             <th class="five wide">Certname</th>
-            <th class="five wide date default-sort">Report</th>
+            <th class="five wide default-sort">Report</th>
             <th class="one wide"></th>
           </tr>
         </thead>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -9,8 +9,8 @@
     <tr>
       <th>Status</th>
       <th class="default">Certname</th>
-      <th class="date default-sort">Catalog</th>
-      <th class="date">Report</th>
+      <th class="default-sort">Catalog</th>
+      <th>Report</th>
       <th>&nbsp;</th>
     </tr>
   </thead>


### PR DESCRIPTION
Related to #399

This change makes sorting by date on the nodes page work.

I noticed the date class seems to trigger the code on line 13 in `Puppetboard / puppetboard / static / js / tables.js`. But other pages, for example Catalogs, have dates that don't use the `.date` class and work.

So I removed the date class and it seems to fix the issue.

I'm wondering if this tables.js code for dates is being used elsewhere, if so is it working, if not should it be removed?