### PR TITLE
Fix sort by date on nodes and index page

### DIFF
--- a/puppetboard/static/js/tables.js
+++ b/puppetboard/static/js/tables.js
@@ -11,8 +11,9 @@
   }
 
   $('thead th.date').data('sortBy', function(th, td, tablesort) {
-    var tdTime = td.text().replace("-", "");
-    return moment.utc(new Date(tdTime)).unix();
+    var tdTime = new Date(td.text().replace("-", ""));
+    if(isNaN(tdTime)) return 0;
+    else return tdTime;
   });
 
   $('input.filter-table').parent('div').removeClass('hide');

--- a/puppetboard/static/js/tables.js
+++ b/puppetboard/static/js/tables.js
@@ -12,7 +12,7 @@
 
   $('thead th.date').data('sortBy', function(th, td, tablesort) {
     var tdTime = td.text().replace("-", "");
-    return moment.utc(tdTime).unix();
+    return moment.utc(new Date(tdTime)).unix();
   });
 
   $('input.filter-table').parent('div').removeClass('hide');

--- a/puppetboard/static/js/tables.js
+++ b/puppetboard/static/js/tables.js
@@ -11,7 +11,8 @@
   }
 
   $('thead th.date').data('sortBy', function(th, td, tablesort) {
-    return moment.utc(td.text()).unix();
+    var tdTime = td.text().replace("-", "");
+    return moment.utc(tdTime).unix();
   });
 
   $('input.filter-table').parent('div').removeClass('hide');

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -87,7 +87,7 @@
           <tr>
             <th class="five wide">Status</th>
             <th class="five wide">Certname</th>
-            <th class="five wide default-sort">Report</th>
+            <th class="date five wide default-sort">Report</th>
             <th class="one wide"></th>
           </tr>
         </thead>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -9,8 +9,8 @@
     <tr>
       <th>Status</th>
       <th class="default">Certname</th>
-      <th class="default-sort">Catalog</th>
-      <th>Report</th>
+      <th class="date default-sort">Catalog</th>
+      <th class="date">Report</th>
       <th>&nbsp;</th>
     </tr>
   </thead>


### PR DESCRIPTION
This is a follow up to #400 

I'm removing this code because I can't find it referenced anywhere other than the places I removed it from.

I realize this pull request doesn't add any functionality, but if someone adds a class of date to a `th` element this change will stop the functionality from breaking.