### PR TITLE
Issue #394 stop 404 to daily_report.json

### DIFF
--- a/puppetboard/templates/node.html
+++ b/puppetboard/templates/node.html
@@ -1,17 +1,5 @@
 {% extends 'layout.html' %}
 {% import '_macros.html' as macros %}
-{% block head %}
-{% if config.DAILY_REPORTS_CHART_ENABLED %}
-<link href="{{ url_for('static', filename='css/c3.min.css') }}" rel="stylesheet" />
-{% endif %}
-{% block script %}
-{% if config.DAILY_REPORTS_CHART_ENABLED %}
-<script src="{{url_for('static', filename='js/d3.min.js')}}"></script>
-<script src="{{url_for('static', filename='js/c3.min.js')}}"></script>
-<script src="{{url_for('static', filename='js/dailychart.js')}}"></script>
-{% endif %}
-{% endblock script %}
-{% endblock head %}
 {% block onload_script %}
 {% macro extra_options(caller) %}
   'pagingType': 'simple',


### PR DESCRIPTION
I was looking at issue #394 and I noticed the scripts from the Overview page relating to the d3 chart are being loaded on node.html. 

Once `dailychart.js` is removed the 404 is gone.