### PR TITLE
Preety print multiline diff messages from puppetdb

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -550,8 +550,8 @@ def report(env, node_name, report_id):
 
     report_logs = []
     for log_dict in report.logs:
-      log_dict['message'] = log_dict['message'].split('\n')
-      report_logs.append(log_dict)
+        log_dict['message'] = log_dict['message'].split('\n')
+        report_logs.append(log_dict)
 
     return render_template(
         'report.html',

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -548,11 +548,16 @@ def report(env, node_name, report_id):
 
     report.version = CommonMark.commonmark(report.version)
 
+    report_logs = []
+    for log_dict in report.logs:
+      log_dict['message'] = log_dict['message'].split('\n')
+      report_logs.append(log_dict)
+
     return render_template(
         'report.html',
         report=report,
         events=yield_or_stop(report.events()),
-        logs=report.logs,
+        logs=report_logs,
         metrics=report.metrics,
         envs=envs,
         current_env=env)

--- a/puppetboard/templates/report.html
+++ b/puppetboard/templates/report.html
@@ -77,7 +77,7 @@
         <td rel="utctimestamp">{{log.time}}</td>
         <td>{{log.source}}</td>
         <td>{{log.tags|join(', ')}}</td>
-        <td>{{log.message}}</td>
+        <td>{% for para in log.message %}<p>{{para}}</p>{% endfor %}</td>
         {% if log.file != None and log.line != None %}
           <td>{{log.file}}:{{log.line}}</td>
         {% else %}


### PR DESCRIPTION
This PR fixes unreadable diff (and other multiline) messages from puppetdb - it splits message by newline character and show in separate paragraph.