### PR TITLE
Docker build needs to use light weight tags

### DIFF
--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-version=$(git describe HEAD --abbrev=4)
+
+
+git_version=$(git describe HEAD --tags --abbrev=4)
+
+
+if [ ${SOURCE_BRANCH} == "master" ]
+then
+    version=$git_version
+else
+    version=$(echo ${SOURCE_BRANCH} | sed 's/v//')
+fi
 
 cat << EOF > puppetboard/version.py
 #


### PR DESCRIPTION
to get the proper version from GitHub releases.

Only use git describe when docker builds master
use the tag name which is stored in the environment
variable SOURCE_BRANCH.

See:
https://docs.docker.com/docker-cloud/builds/advanced/#override-build-test-or-push-commands