### PR TITLE
semantic.min.css not found when OFFLINE_MODE is enabled

### DIFF
--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -13,7 +13,7 @@
       }
     </style>
     <link href='{{ url_for('static', filename='jquery-datatables-1.10.13/dataTables.semanticui.min.css') }}' rel='stylesheet' type='text/css'>
-    <link href="{{ url_for('offline_static', filename='Semantic-UI-2.1.8/semantic.min.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('static', filename='Semantic-UI-2.1.8/semantic.min.css') }}" rel="stylesheet" />
     {% else %}
     <link href='//fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css' />
     <link href="{{ url_for('static', filename='Semantic-UI-2.1.8/semantic.min.css') }}" rel="stylesheet" />


### PR DESCRIPTION
Hi!

Just updated Puppetboard to 0.3.0 and I'm having some CSS problems when I leave enabled the offline mode.

Found this in the logs:
`[Tue Oct 17 20:40:21.996344 2017] [wsgi:error] [pid 54588] TemplateNotFound: static/Semantic-UI-2.1.8/semantic.min.css`

And when I checked the HTML code I found this:

> #OFFLINE MODE=True
`<link href="/offline/Semantic-UI-2.1.8/semantic.min.css" rel="stylesheet" />
`
> #OFFLINE_MODE=False
`<link href="/static/Semantic-UI-2.1.8/semantic.min.css" rel="stylesheet" />`

Thanks in advance!