### PR TITLE
Make 320px the max width for columns #404

### DIFF
--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -25,6 +25,7 @@ h1.ui.header.no-margin-bottom {
 
 .ui.table[class*="very compact"] td {
   padding: 0.15em 0.1em;
+  max-width: 320px;
 }
 
 .factlist li {


### PR DESCRIPTION
This pull request helps with a layout issue I pointed out in #404. The Certname column is sometimes too long which makes the buttons display not as intended. 

In particular I found this helps on screens 1200px-1500px when cert-names are long.