### PR TITLE
remove duplicate c3.js/d3.js links

### DIFF
--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -6,6 +6,7 @@
 {% endif %}
 {% if config.DAILY_REPORTS_CHART_ENABLED %}
 {% block script %}
+<script src="{{url_for('static', filename='js/c3.min.js')}}"></script>
 <script src="{{url_for('static', filename='js/d3.min.js')}}"></script>
 <script src="{{url_for('static', filename='js/dailychart.js')}}"></script>
 {% endblock script %}

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -6,8 +6,8 @@
 {% endif %}
 {% if config.DAILY_REPORTS_CHART_ENABLED %}
 {% block script %}
-<script src="{{url_for('static', filename='js/c3.min.js')}}"></script>
 <script src="{{url_for('static', filename='js/d3.min.js')}}"></script>
+<script src="{{url_for('static', filename='js/c3.min.js')}}"></script>
 <script src="{{url_for('static', filename='js/dailychart.js')}}"></script>
 {% endblock script %}
 {% endif %}

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -7,7 +7,6 @@
 {% if config.DAILY_REPORTS_CHART_ENABLED %}
 {% block script %}
 <script src="{{url_for('static', filename='js/d3.min.js')}}"></script>
-<script src="{{url_for('static', filename='js/c3.min.js')}}"></script>
 <script src="{{url_for('static', filename='js/dailychart.js')}}"></script>
 {% endblock script %}
 {% endif %}

--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -19,7 +19,6 @@
     <link href="{{ url_for('static', filename='Semantic-UI-2.1.8/semantic.min.css') }}" rel="stylesheet" />
     <link href='//cdnjs.cloudflare.com/ajax/libs/datatables/1.10.13/css/dataTables.semanticui.min.css' rel='stylesheet' type='text/css'>
     {% endif %}
-    <link href="{{ url_for('static', filename='css/c3.min.css') }}" rel="stylesheet" />
     <link href="{{ url_for('static', filename='css/puppetboard.css') }}" rel="stylesheet" />
 
     {% if config.OFFLINE_MODE %}
@@ -43,8 +42,6 @@
     <script src="{{ url_for('static', filename='Semantic-UI-2.1.8/semantic.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/lists.js') }}"></script>
     <script src="{{ url_for('static', filename='js/scroll.top.js') }}"></script>
-    <script src="{{url_for('static', filename='js/d3.min.js')}}"></script>
-    <script src="{{url_for('static', filename='js/c3.min.js')}}"></script>
     <script src="{{url_for('static',
                   filename='jquery-tablesort-v.0.0.11/jquery.tablesort.min.js')}}"></script>
     {% block script %} {% endblock script %}


### PR DESCRIPTION
Removing extra links reported in #406 

Even with this change there seems to be 2 of both `d3.js` and `c3.js` on index.