### PR TITLE
Fix: default table sort was always ascending

### DIFF
--- a/puppetboard/static/js/tables.js
+++ b/puppetboard/static/js/tables.js
@@ -12,10 +12,11 @@
     else return tdTime;
   });
 
-  if ($('th.default-sort').data()) {
+  var thDefaultSort = $('th.default-sort');
+  if (thDefaultSort.data()) {
     var tablesort = $('table.sortable').tablesort().data('tablesort');
-    tablesort.index = $('th.default-sort').index();
-    tablesort.sort($("th.default-sort"), 'desc');
+    tablesort.index = thDefaultSort.index();
+    tablesort.sort(thDefaultSort, 'desc');
   }
 
 

--- a/puppetboard/static/js/tables.js
+++ b/puppetboard/static/js/tables.js
@@ -7,7 +7,11 @@
   $(function() {});
 
   if ($('th.default-sort').data()) {
-    $('table.sortable').tablesort().data('tablesort').sort($("th.default-sort"), "desc");
+    $.tablesort.DEBUG = false;
+    var tablesort = $('table.sortable').tablesort().data('tablesort');
+    // explicitly set the current index so we don't get default sort (asc)
+    tablesort.index = $('th.default-sort').index();
+    tablesort.sort($("th.default-sort"), 'desc');
   }
 
   $('thead th.date').data('sortBy', function(th, td, tablesort) {

--- a/puppetboard/static/js/tables.js
+++ b/puppetboard/static/js/tables.js
@@ -6,19 +6,18 @@
 
   $(function() {});
 
-  if ($('th.default-sort').data()) {
-    $.tablesort.DEBUG = false;
-    var tablesort = $('table.sortable').tablesort().data('tablesort');
-    // explicitly set the current index so we don't get default sort (asc)
-    tablesort.index = $('th.default-sort').index();
-    tablesort.sort($("th.default-sort"), 'desc');
-  }
-
   $('thead th.date').data('sortBy', function(th, td, tablesort) {
     var tdTime = new Date(td.text().replace("-", ""));
     if(isNaN(tdTime)) return 0;
     else return tdTime;
   });
+
+  if ($('th.default-sort').data()) {
+    var tablesort = $('table.sortable').tablesort().data('tablesort');
+    tablesort.index = $('th.default-sort').index();
+    tablesort.sort($("th.default-sort"), 'desc');
+  }
+
 
   $('input.filter-table').parent('div').removeClass('hide');
 


### PR DESCRIPTION
An ascending sort order is always triggered when then target index is different
from the tablesort index. This was always true on a page (re)load, because
index is initialized with null.  By setting the instance' index to the
default-sort column index we assure that the direction parameter to sort() is
used.

See https://github.com/kylefox/jquery-tablesort/blob/master/jquery.tablesort.js#L42