### PR TITLE
If query is None don't perform add on it.

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -691,7 +691,7 @@ def fact_ajax(env, node, fact, value):
     try:
         value = int(value)
     except ValueError:
-        if value is not None:
+        if value is not None and query is not None:
             query.add(EqualsOperator('value', unquote_plus(value)))
     except TypeError:
         pass


### PR DESCRIPTION
This fixes https://github.com/voxpupuli/puppetboard/issues/437.

Based on the feedback on the issue I realized this only triggers when * environment is selected.

The error can be easily simulated with curl. This works `curl http://localhost:5000/production/fact/kernel/Linux/json` but this doesn't `http://localhost:5000/fact/kernel/Linux/json`.

The url without `<env>` returns this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/var/www/puppetboard/puppetboard/app.py", line 789, in fact_ajax
    query.add(EqualsOperator('value', unquote_plus(value)))
AttributeError: 'NoneType' object has no attribute 'add'
```
By not allowing that line to run if query is empty the error is avoided. 