### PR TITLE
View of structured facts

### DIFF
--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -56,7 +56,17 @@
     "search": {"regex": true},
     // Default sort
     "order": [[ 0, "desc" ]],
-    // Custom options
+   // Rendering - add rendering options for columns
+    "columnDefs": [ {
+      "targets": -1,
+      "data:": null,
+      "render": function (data, type, full, meta) {
+       shorta = data.replace(/[{},]/g, "<br />");
+       shortb = shorta.replace(/u'/g, " "); 
+       shortc = shortb.replace(/'/g, " "); 
+       return shortc;
+       }}],
+      // Custom options
     {% if extra_options %}{% call extra_options() %}Callback to parent defined options{% endcall %}{% endif %}
   });
 


### PR DESCRIPTION
Line breaks were added allowing see the facts in a structured way, e.g. for disks:

![view_of_facts](https://user-images.githubusercontent.com/32731446/36193974-385415dc-1168-11e8-8ca6-7c74b2e8e770.png)
