### PR TITLE
Fix documentation error regarding ENABLE_CATALOG

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ Usage:
     -e PUPPETDB_KEY=/etc/puppetlabs/puppetdb/ssl/private.pem \
     -e PUPPETDB_CERT=/etc/puppetlabs/puppetdb/ssl/public.pem \
     -e INVENTORY_FACTS='Hostname,fqdn, IP Address,ipaddress' \
-    -e ENABLE_CATALOG=true \
+    -e ENABLE_CATALOG=True \
     -e GRAPH_FACTS='architecture,puppetversion,osfamily' \
     puppetboard
 


### PR DESCRIPTION
True or False are expected (python booleans start with capital letters)