### PR TITLE
Adding basic health check endpoint

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -1104,3 +1104,8 @@ def offline_static(filename):
 
     return Response(response=render_template('static/%s' % filename),
                     status=200, mimetype=mimetype)
+
+
+@app.route('/status')
+def health_status():
+    return 'OK'

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -857,3 +857,10 @@ def test_custom_title(client, mocker):
     rv = client.get('/')
     soup = BeautifulSoup(rv.data, 'html.parser')
     assert soup.title.contents[0] == custom_title
+
+
+def test_health_status(client):
+    rv = client.get('/status')
+
+    assert rv.status_code == 200
+    assert rv.data.decode('utf-8') == 'OK'


### PR DESCRIPTION
The endpoint /status can be used to determine if puppetboard is running or not.
Reason for needing an endpoint like this is because if the puppetdb has no
data yet (due to a fresh install for example), it will return a 404 on all pages.
This will throw off health checks for example docker or the AWS ALB.

The health check endpoint can later be expanded by puppetdb health as soon
as this functionality has been merged in the pypuppetdb module.