### PR TITLE
Allow to configure enabled query endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ Other settings that might be interesting in no particular order:
 -   `PUPPETDB_TIMEOUT`: Defaults to 20 seconds but you might need to increase this value. It depends on how big the results are when querying PuppetDB. This behaviour will change in a future release when pagination will be introduced.
 -   `UNRESPONSIVE_HOURS`: The amount of hours since the last check-in after which a node is considered unresponsive.
 -   `LOGLEVEL`: A string representing the loglevel. It defaults to `'info'` but can be changed to `'warning'` or `'critical'` for less verbose logging or `'debug'` for more information.
--   `ENABLE_QUERY`: Defaults to `True` causing a Query tab to show up in the web interface allowing users to write and execute arbitrary queries against a set of endpoints in PuppetDB. Change this to `False` to disable this.
+-   `ENABLE_QUERY`: Defaults to `True` causing a Query tab to show up in the web interface allowing users to write and execute arbitrary queries against a set of endpoints in PuppetDB. Change this to `False` to disable this. See `ENABLED_QUERY_ENDPOINTS` to fine-tune which endpoints are allowed.
+-   `ENABLED_QUERY_ENDPOINTS`: If `ENABLE_QUERY` is `True`, allow to fine tune the endpoints of PuppetDB APIs that can be queried. It must be a list of strings of PuppetDB endpoints for which the query is enabled. See the `QUERY_ENDPOINTS` constant in the `puppetboard.app` module for a list of the available endpoints.
 -   `GRAPH_TYPE`: Specify the type of graph to display.   Default is
     pie, other good option is donut.   Other choices can be found here:
     \_C3JS\_documentation\`

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -14,6 +14,8 @@ DEV_LISTEN_PORT = 5000
 DEV_COFFEE_LOCATION = 'coffee'
 UNRESPONSIVE_HOURS = 2
 ENABLE_QUERY = True
+# Uncomment to restrict the enabled PuppetDB endpoints in the query page.
+# ENABLED_QUERY_ENDPOINTS = ['facts', 'nodes']
 LOCALISE_TIMESTAMP = True
 LOGLEVEL = 'info'
 NORMAL_TABLE_COUNT = 100

--- a/puppetboard/docker_settings.py
+++ b/puppetboard/docker_settings.py
@@ -23,6 +23,8 @@ DEV_LISTEN_PORT = int(os.getenv('DEV_LISTEN_PORT', '5000'))
 DEV_COFFEE_LOCATION = os.getenv('DEV_COFFEE_LOCATION', 'coffee')
 UNRESPONSIVE_HOURS = int(os.getenv('UNRESPONSIVE_HOURS', '2'))
 ENABLE_QUERY = os.getenv('ENABLE_QUERY', 'True')
+# Uncomment to restrict the enabled PuppetDB endpoints in the query page.
+# ENABLED_QUERY_ENDPOINTS = ['facts', 'nodes']
 
 LOCALISE_TIMESTAMP = bool(os.getenv('LOCALISE_TIMESTAMP',
                                     'True').upper() == 'TRUE')

--- a/puppetboard/forms.py
+++ b/puppetboard/forms.py
@@ -1,11 +1,35 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+from collections import OrderedDict
+
 from flask_wtf import FlaskForm
 from wtforms import (
     HiddenField, RadioField, SelectField,
     TextAreaField, BooleanField, validators
 )
+
+from puppetboard.core import get_app
+
+
+app = get_app()
+QUERY_ENDPOINTS = OrderedDict([
+    # PuppetDB API endpoint, Form name
+    ('nodes', 'Nodes'),
+    ('resources', 'Resources'),
+    ('facts', 'Facts'),
+    ('factsets', 'Fact Sets'),
+    ('fact-paths', 'Fact Paths'),
+    ('fact-contents', 'Fact Contents'),
+    ('reports', 'Reports'),
+    ('events', 'Events'),
+    ('catalogs', 'Catalogs'),
+    ('edges', 'Edges'),
+    ('environments', 'Environments'),
+    ('pql', 'PQL'),
+])
+ENABLED_QUERY_ENDPOINTS = app.config.get(
+    'ENABLED_QUERY_ENDPOINTS', list(QUERY_ENDPOINTS.keys()))
 
 
 class QueryForm(FlaskForm):
@@ -14,17 +38,6 @@ class QueryForm(FlaskForm):
     query = TextAreaField('Query', [validators.Required(
         message='A query is required.')])
     endpoints = RadioField('API endpoint', choices=[
-        ('nodes', 'Nodes'),
-        ('resources', 'Resources'),
-        ('facts', 'Facts'),
-        ('factsets', 'Fact Sets'),
-        ('fact-paths', 'Fact Paths'),
-        ('fact-contents', 'Fact Contents'),
-        ('reports', 'Reports'),
-        ('events', 'Events'),
-        ('catalogs', 'Catalogs'),
-        ('edges', 'Edges'),
-        ('environments', 'Environments'),
-        ('pql', 'PQL'),
-    ])
+        (key, value) for key, value in QUERY_ENDPOINTS.items()
+        if key in ENABLED_QUERY_ENDPOINTS])
     rawjson = BooleanField('Raw JSON')


### PR DESCRIPTION
Allow to configure which PuppetDB endpoints are allowed in the `/query`
page, adding the `ENABLED_QUERY_ENDPOINTS` configuration variable, that
if set restricts the allowed endpoints to query. If not set the previous
behaviour is kept, allowing all PuppetDB endpoints to be queried, if the
`ENABLE_QUERY` configuration is `True`.

Closes: #475