### PR TITLE
CommonMark >= 0.8.x preparation

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -25,7 +25,11 @@ from puppetboard.utils import (get_or_abort, yield_or_stop,
 from puppetboard.dailychart import get_daily_reports_chart
 
 import werkzeug.exceptions as ex
-import CommonMark
+
+try:
+    import CommonMark as commonmark
+except ImportError:
+    import commonmark
 
 from puppetboard.core import get_app, get_puppetdb, environments
 import puppetboard.errors
@@ -546,7 +550,7 @@ def report(env, node_name, report_id):
     except StopIteration:
         abort(404)
 
-    report.version = CommonMark.commonmark(report.version)
+    report.version = commonmark.commonmark(report.version)
 
     return render_template(
         'report.html',


### PR DESCRIPTION
As commonmark package has been renamed to lowercase and removed symlink starting v0.8.1 it will be a good point to import the module directly to lowercase in order to remove the try: block in the future when using a later version of this package:
https://github.com/rtfd/CommonMark-py/releases