### PR TITLE
Add support for URL prefixes to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r requirements-docker.txt
 
 COPY . /usr/src/app
 
-CMD gunicorn -b 0.0.0.0:${PUPPETBOARD_PORT} --access-logfile=/dev/stdout puppetboard.app:app
+CMD gunicorn -b 0.0.0.0:${PUPPETBOARD_PORT} -e SCRIPT_NAME="${PUPPETBOARD_URL_PREFIX:-}" --access-logfile=/dev/stdout puppetboard.app:app

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ $ docker run -it -p 9080:80 -v /etc/puppetlabs/puppet/ssl:/etc/puppetlabs/puppet
   puppetboard
 ```
 
+To set a URL prefix you can use the optional `PUPPETBOARD_URL_PREFIX`
+environment variable.
+
 ### Development
 
 If you wish to hack on Puppetboard you should fork/clone the Github repository and then install the requirements through:
@@ -639,4 +642,3 @@ Screenshots
 ![Query view](screenshots/query.png)
 
 ![Error page](screenshots/broken.png)
-


### PR DESCRIPTION
This change makes it a bit easier to deploy Docker images of Puppetboard without having to run the service on its own subdomain.