### PR TITLE
Move to Python 3.6 for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-alpine
+FROM python:3.6-alpine
 
 ENV PUPPETBOARD_PORT 80
 EXPOSE 80


### PR DESCRIPTION
Since Python 2.x [is getting deprecated as of January 2020](https://pythonclock.org/), shouldn't we move to 3.6 for the supplied Dockerfile?