### PR TITLE
Ignore facts environment for compatibility and performance

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -131,7 +131,6 @@ def index(env):
     else:
         query = AndOperator()
         query.add(EqualsOperator('catalog_environment', env))
-        query.add(EqualsOperator('facts_environment', env))
 
         num_nodes_query = ExtractOperator()
         num_nodes_query.add_field(FunctionOperator('count'))
@@ -222,7 +221,6 @@ def nodes(env):
 
     if env != '*':
         query.add(EqualsOperator("catalog_environment", env))
-        query.add(EqualsOperator("facts_environment", env))
 
     if status_arg in ['failed', 'changed', 'unchanged']:
         query.add(EqualsOperator('latest_report_status', status_arg))
@@ -1006,7 +1004,6 @@ def radiator(env):
         metric_query = ExtractOperator()
 
         query.add(EqualsOperator("catalog_environment", env))
-        query.add(EqualsOperator("facts_environment", env))
         metric_query.add_field(FunctionOperator('count'))
         metric_query.add_query(query)
 


### PR DESCRIPTION
Fixes #496

Because of https://tickets.puppetlabs.com/browse/PUP-9290 if someone
is using `puppet facts upload` their nodes have facts_environment set
always to "production". This breaks filtering in Puppetboard.
But it's both safe and beneficial to just ignore facts_environment
and depend only on catalog_environment to filter nodes by environment
because if a node is in env X then it mean that it has catalog_environment
set to X.