### PR TITLE
Updating pypuppetdb dependency to 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ MarkupSafe >=0.19
 WTForms >=2.1
 Werkzeug >=0.12.1
 itsdangerous >=0.23
-pypuppetdb >=1.0.0
+pypuppetdb >=1.2.0
 requests >=2.13.0
 CommonMark==0.7.2


### PR DESCRIPTION
Updating version of pypuppetdb to avoid missing requirements-test.txt issue present in versions 1.0.0 and 1.1.0.

This change is required to fix deployment issues with the current puppet-puppetboard module. It's a precursor a new release of the puppetboard module.