### PR TITLE
Dropping support for python2.7 and python3.5 and adding python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 dist: xenial
 language: python
 python:
-  - &latest_py2 2.7
-  - 3.5
   - 3.6
-  - &latest_py3 3.7
+  - 3.7
+  - &latest_py3 3.8
 
 jobs:
   fast_finish: true
   include:
   - python: *latest_py3
-    env: LANG=C
-  - python: *latest_py2
     env: LANG=C
   - stage: deploy (to PyPI for tagged commits)
     if: tag IS present

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ As of version 0.1.0 and higher, Puppetboard **requires** PuppetDB 3. Version 0.3
 
 At the current time of writing, Puppetboard supports the following Python versions:
 
-* Python 2.7 (NB! [Python 2.7 is deprecated and should not be used](https://pythonclock.org/))
-* Python 3.5
 * Python 3.6
 * Python 3.7
+* Python 3.8
 
 ![View of a node](screenshots/overview.png)
 
@@ -330,7 +329,7 @@ Here is a sample configuration for Fedora:
     CustomLog logs/puppetboard-access_log combined
 
     Alias /static /usr/lib/pythonX.Y/site-packages/puppetboard/static
-    <Directory /usr/lib/python2.X/site-packages/puppetboard/static>
+    <Directory /usr/lib/pythonX.Y/site-packages/puppetboard/static>
         Satisfy Any
         Allow from all
     </Directory>
@@ -533,7 +532,7 @@ import multiprocessing
 
 bind    = '127.0.0.1:9090'
 workers = multiprocessing.cpu_count() * 2 + 1
-chdir   = '/usr/lib/python2.7/site-packages/puppetboard'
+chdir   = '/usr/lib/pythonX.Y/site-packages/puppetboard'
 raw_env = ['PUPPETBOARD_SETTINGS=/var/www/puppetboard/settings.py', 'http_proxy=']
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -66,11 +66,9 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
Python 2.7 is deprecated in 2 months from now, so it's no longer necessary to support it for next release.
Python 3.8 is released, I think it's good to add it and drop Python 3.5.