### PR TITLE
Update docker and fix coveralls not running.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 ENV PUPPETBOARD_PORT 80
 EXPOSE 80
@@ -7,8 +7,11 @@ ENV PUPPETBOARD_SETTINGS docker_settings.py
 RUN mkdir -p /usr/src/app/
 WORKDIR /usr/src/app/
 
+# Workaround for https://github.com/benoitc/gunicorn/issues/2160
+RUN apk --update --no-cache add libc-dev binutils
+
 COPY requirements*.txt /usr/src/app/
-RUN pip install -r requirements-docker.txt
+RUN pip install --no-cache-dir -r requirements-docker.txt
 
 COPY . /usr/src/app
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,7 @@ filterwarnings =
     ignore::DeprecationWarning
 markers =
     pep8: workaround for https://bitbucket.org/pytest-dev/pytest-pep8/issues/23/
+addopts = --cov=puppetboard --cov-report=term-missing
+norecursedirs = docs .tox venv .eggs lib
+pep8ignore = E402
+python_files = test/*.py

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-gunicorn==19.6.0
+gunicorn==20.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,14 +1,14 @@
 -r requirements.txt
-pep8==1.7.1
-coverage==4.5.4
-mock==3.0.5
-pytest==5.2.2
-pytest-pep8==1.0.6
-pytest-cov==2.8.1
-pytest-mock==1.11.2
-pytest-mypy==0.4.1
-cov-core==1.15.0
-beautifulsoup4==4.8.1
+pep8
+coverage
+mock
+pytest
+pytest-pep8
+pytest-cov
+pytest-mock
+pytest-mypy
+cov-core
+beautifulsoup4
 bandit
 coveralls
-mypy==0.740
+mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,3 @@ cover-package = puppetboard
 
 [flake8]
 exclude=venv
-
-[tool:pytest]
-addopts = --cov=puppetboard --cov-report=term-missing
-norecursedirs = docs .tox venv .eggs lib
-pep8ignore = E402
-python_files = test/*.py


### PR DESCRIPTION
Gunicorn 20.0.0 is released so we can finally update Dockerfile to use Python3.8.
Additionally fixing coveralls not running and moving whole config for pytests to single file.