### PR TITLE
Cast inventory data toString.

### DIFF
--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -61,7 +61,7 @@
       "targets": -1,
       "data:": null,
       "render": function (data, type, full, meta) {
-       shorta = data.replace(/[{},]/g, "<br />");
+       shorta = data.toString().replace(/[{},]/g, "<br />");
        shortb = shorta.replace(/u'/g, " "); 
        shortc = shortb.replace(/'/g, " "); 
        return shortc;


### PR DESCRIPTION
This prevents a type error for fact values in the inventory page that are numeric.  Some of our custom facts simply return a numeric count which causes the replace function to fail unless it's cast as a string.