### PR TITLE
Update app.py

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-
-from urllib.parse import unquote, unquote_plus, quote_plus
+try:
+    from urllib import unquote, unquote_plus, quote_plus  # Python 2.X
+except ImportError:
+    from urllib.parse import unquote, unquote_plus, quote_plus  # Python 3+
+    
 from datetime import datetime, timedelta
 from itertools import tee
 import sys


### PR DESCRIPTION
urllib.parse is for Python 3.x and doesn't work in 2.x. This totally broke the Puppetboard. The above will fix the issue for this file. The same problem needs fixing in api.py from https://github.com/voxpupuli/pypuppetdb/blob/master/pypuppetdb/api.py

Unfortunately, it looks like Python 2.7 support was intentionally removed from PyPuppetDB. This isn't helpful when it essentially totally breaks this module :(