### PR TITLE
Version lock pypuppetdb version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ MarkupSafe >=0.19
 WTForms >=2.1
 Werkzeug >=0.12.1
 itsdangerous >=0.23
-pypuppetdb >=1.0.0
+pypuppetdb >=1.2.0
 requests >=2.13.0
 CommonMark==0.7.2


### PR DESCRIPTION
PuppetBoard is still not Python 3 compatible. As such we need to version lock PyPuppetDB to a Python 2 compatible version. Right now PuppetBoard is broken. :( 

Hopefully work can start to convert this module to Python 3 as it's still very useful.