### PR TITLE
Fixing the requirements.txt as it's breaking Puppetboard.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ MarkupSafe >=1.1.1
 WTForms >=2.2.1
 Werkzeug >=0.16.0
 itsdangerous >=1.1.0
-pypuppetdb >=2.0.0
+pypuppetdb <2.0.0
 requests >=2.22.0
 CommonMark==0.9.1


### PR DESCRIPTION
This module is NOT compatible with Python 3.x The latest versions of PyPuppetDB (>2.x) are Python 3 only. 

Until PuppetBoard is updated to use Python 3 please change this back to ensure the module works. This change was obviously not correctly tested as it breaks Puppet board.