### PR TITLE
Update app.py to support fallback to Python 2.7

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-
-from urllib.parse import unquote, unquote_plus, quote_plus
+# load python 3, fallback to python 2 if it fails
 try:
-    from urllib.parse import unquote, unquote_plus, quote_plus  # Python 3+
+    from urllib.parse import unquote, unquote_plus, quote_plus
 except ImportError:
-    # Fallback for Python 2.x support
-    from urllib import unquote, unquote_plus, quote_plus  # Python 2.X
-    
+    from urllib import unquote, unquote_plus, quote_plus  # type: ignore
+
 from datetime import datetime, timedelta
 from itertools import tee
 import sys

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -3,6 +3,12 @@ from __future__ import unicode_literals
 
 
 from urllib.parse import unquote, unquote_plus, quote_plus
+try:
+    from urllib.parse import unquote, unquote_plus, quote_plus  # Python 3+
+except ImportError:
+    # Fallback for Python 2.x support
+    from urllib import unquote, unquote_plus, quote_plus  # Python 2.X
+    
 from datetime import datetime, timedelta
 from itertools import tee
 import sys


### PR DESCRIPTION
Currently Puppetboard doesn't work on Systems still using Python 2.7 wsgi so we need to try and fallback on the old urllib import.