### PR TITLE
Fixed bugs in metrics v2 usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Development
 
 * Fixed Puppetboard's usage for the new metrics v2 API both on the home page for computing the average resources/node and the `Metrics` listing page. This change now supports the changes in PuppetDB >= 6.9.1 (https://puppet.com/security/cve/CVE-2020-7943/)
 * pypuppetdb: raise version requirement `>=2.1.0` because changes were needed in this library to support the metrics v2 fixes.
+* app.py: Added python2 backwards compatability fix for importing `urllib`.
 
 2.0.0
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Development
 -----------
 
 * Fixed Puppetboard's usage for the new metrics v2 API both on the home page for computing the average resources/node and the `Metrics` listing page. This change now supports the changes in PuppetDB >= 6.9.1 (https://puppet.com/security/cve/CVE-2020-7943/)
+* Added backwards compatability support for both the metric `v1` and `v2` endpoints
+  depending on the version of the server. Any PuppetDB >= `6.9.1` will be queried with
+  the `v2` endpoint automatically (because `v1` is disabled from here forward). Any
+  PuppetDB <= `6.9.0` will use `v1`.
 * pypuppetdb: raise version requirement `>=2.1.0` because changes were needed in this library to support the metrics v2 fixes.
 * app.py: Added python2 backwards compatability fix for importing `urllib`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 This is the changelog for Puppetboard.
 
+Development
+-----------
+
+* Fixed Puppetboard's usage for the new metrics v2 API both on the home page for computing the average resources/node and the `Metrics` listing page. This change now supports the changes in PuppetDB >= 6.9.1 (https://puppet.com/security/cve/CVE-2020-7943/)
+* pypuppetdb: raise version requirement `>=2.1.0` because changes were needed in this library to support the metrics v2 fixes.
+
 2.0.0
 ----
 

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 
-from urllib.parse import unquote, unquote_plus, quote_plus
+# load python 3, fallback to python 2 if it fails
+try:
+    from urllib.parse import unquote, unquote_plus, quote_plus
+except ImportError:
+    from urllib import unquote, unquote_plus, quote_plus  # type: ignore
 from datetime import datetime, timedelta
 from itertools import tee
 import sys
@@ -835,9 +839,9 @@ def metrics(env):
     metrics_domains = get_or_abort(puppetdb.metrics)
     metrics = []
     # get all of the domains
-    for domain in metrics_domains.keys():
+    for domain in list(metrics_domains.keys()):
         # iterate over all of the properties in this domain
-        properties = metrics_domains[domain].keys()
+        properties = list(metrics_domains[domain].keys())
         for prop in properties:
             # combine the current domain and each property with a ":" in between
             metrics.append(domain + ':' + prop)

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -81,6 +81,23 @@ def check_env(env, envs):
         abort(404)
 
 
+def metric_params(db_version):
+    query_type = ''
+
+    # PuppetDB moved to a new metrics API (v2) in 6.9.1
+    if db_version > (6, 9, 0):
+        metric_version = 'v2'
+    else:
+        metric_version = 'v1'
+
+    # Puppet DB version changed the query format from 3.2.0
+    # to 4.0 when querying mbeans
+    if db_version < (4, 0, 0):
+        query_type = 'type=default,'
+
+    return query_type, metric_version
+
+
 @app.context_processor
 def utility_processor():
     def now(format='%m/%d/%Y %H:%M:%S'):
@@ -110,29 +127,28 @@ def index(env):
         query = app.config['OVERVIEW_FILTER']
 
         prefix = 'puppetlabs.puppetdb.population'
-        query_type = ''
-
-        # Puppet DB version changed the query format from 3.2.0
-        # to 4.0 when querying mbeans
-        if get_db_version(puppetdb) < (4, 0, 0):
-            query_type = 'type=default,'
+        db_version = get_db_version(puppetdb)
+        query_type, metric_version = metric_params(db_version)
 
         num_nodes = get_or_abort(
             puppetdb.metric,
-            "{0}{1}".format(prefix, ':%sname=num-nodes' % query_type))
+            "{0}{1}".format(prefix, ':%sname=num-nodes' % query_type),
+            version=metric_version)
         num_resources = get_or_abort(
             puppetdb.metric,
-            "{0}{1}".format(prefix, ':%sname=num-resources' % query_type))
+            "{0}{1}".format(prefix, ':%sname=num-resources' % query_type),
+            version=metric_version)
         avg_resources_node = get_or_abort(
             puppetdb.metric,
             "{0}{1}".format(prefix,
-                            ':%sname=avg-resources-per-node' % query_type))
+                            ':%sname=avg-resources-per-node' % query_type),
+            version=metric_version)
         metrics['num_nodes'] = num_nodes['Value']
         metrics['num_resources'] = num_resources['Value']
         try:
-            # Compute our own average because avg_resources_node['Value'] returns
-            # a string of the format "num_resources/num_nodes" example: "1234/9"
-            # instead of doing the division itself.
+            # Compute our own average because avg_resources_node['Value']
+            # returns a string of the format "num_resources/num_nodes"
+            # example: "1234/9" instead of doing the division itself.
             metrics['avg_resources_node'] = "{0:10.0f}".format(
                 (num_resources['Value'] / num_nodes['Value']))
         except ZeroDivisionError:
@@ -818,33 +834,44 @@ def metrics(env):
     envs = environments()
     check_env(env, envs)
 
-    # the list response is a dict in the format:
-    # {
-    #   "domain1": {
-    #     "property1": {
-    #      ...
-    #     }
-    #   },
-    #   "domain2": {
-    #     "property2": {
-    #      ...
-    #     }
-    #   }
-    # }
-    # The MBean names are the combination of the domain and the properties
-    # with a ":" in between, example:
-    #   domain1:property1
-    #   domain2:property2
-    # reference: https://jolokia.org/reference/html/protocol.html#list
-    metrics_domains = get_or_abort(puppetdb.metrics)
-    metrics = []
-    # get all of the domains
-    for domain in list(metrics_domains.keys()):
-        # iterate over all of the properties in this domain
-        properties = list(metrics_domains[domain].keys())
-        for prop in properties:
-            # combine the current domain and each property with a ":" in between
-            metrics.append(domain + ':' + prop)
+    db_version = get_db_version(puppetdb)
+    query_type, metric_version = metric_params(db_version)
+    if metric_version == 'v1':
+        mbeans = get_or_abort(puppetdb._query, 'mbean')
+        metrics = list(mbeans.keys())
+    elif metric_version == 'v2':
+        # the list response is a dict in the format:
+        # {
+        #   "domain1": {
+        #     "property1": {
+        #      ...
+        #     }
+        #   },
+        #   "domain2": {
+        #     "property2": {
+        #      ...
+        #     }
+        #   }
+        # }
+        # The MBean names are the combination of the domain and the properties
+        # with a ":" in between, example:
+        #   domain1:property1
+        #   domain2:property2
+        # reference: https://jolokia.org/reference/html/protocol.html#list
+        metrics_domains = get_or_abort(puppetdb.metric)
+        metrics = []
+        # get all of the domains
+        for domain in list(metrics_domains.keys()):
+            # iterate over all of the properties in this domain
+            properties = list(metrics_domains[domain].keys())
+            for prop in properties:
+                # combine the current domain and each property with
+                # a ":" in between
+                metrics.append(domain + ':' + prop)
+    else:
+        raise ValueError("Unknown metric version {} for database version {}"
+                         .format(metric_version, database_version))
+
     return render_template('metrics.html',
                            metrics=sorted(metrics),
                            envs=envs,
@@ -864,8 +891,11 @@ def metric(env, metric):
     envs = environments()
     check_env(env, envs)
 
+    db_version = get_db_version(puppetdb)
+    query_type, metric_version = metric_params(db_version)
+
     name = unquote(metric)
-    metric = get_or_abort(puppetdb.metric, metric)
+    metric = get_or_abort(puppetdb.metric, metric, version=metric_version)
     return render_template(
         'metric.html',
         name=name,
@@ -1028,13 +1058,14 @@ def radiator(env):
     check_env(env, envs)
 
     if env == '*':
-        query_type = ''
-        if get_db_version(puppetdb) < (4, 0, 0):
-            query_type = 'type=default,'
+        db_version = get_db_version(puppetdb)
+        query_type, metric_version = metric_params(db_version)
+
         query = None
         metrics = get_or_abort(
             puppetdb.metric,
-            'puppetlabs.puppetdb.population:%sname=num-nodes' % query_type)
+            'puppetlabs.puppetdb.population:%sname=num-nodes' % query_type,
+            version=metric_version)
         num_nodes = metrics['Value']
     else:
         query = AndOperator()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ MarkupSafe >=1.1.1
 WTForms >=2.2.1
 Werkzeug >=0.16.0
 itsdangerous >=1.1.0
-# pypuppetdb >=2.1.0
-git+https://github.com/nmaludy/pypuppetdb
+pypuppetdb >=2.1.0
 requests >=2.22.0
 CommonMark==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ MarkupSafe >=1.1.1
 WTForms >=2.2.1
 Werkzeug >=0.16.0
 itsdangerous >=1.1.0
-pypuppetdb <2.0.0
+pypuppetdb >=2.1.0
 requests >=2.22.0
 CommonMark==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ MarkupSafe >=1.1.1
 WTForms >=2.2.1
 Werkzeug >=0.16.0
 itsdangerous >=1.1.0
-pypuppetdb >=2.1.0
+# pypuppetdb >=2.1.0
+git+https://github.com/nmaludy/pypuppetdb
 requests >=2.22.0
 CommonMark==0.9.1

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -122,13 +122,71 @@ def test_get_index(client, mocker,
 def test_index_all(client, mocker,
                    mock_puppetdb_environments,
                    mock_puppetdb_default_nodes):
+    # starting with v6.9.1 they changed the metric API to v2
+    # and a totally different format
+    base_str = 'puppetlabs.puppetdb.population:'
+    query_data = {
+        'version': [{'version': '6.9.1'}],
+        'metrics': [
+            {
+                'validate': {
+                    'data': {
+                        'value': {'Value': 10}
+                    },
+                    'checks': {
+                        'path': '%sname=num-nodes' % base_str
+                    }
+                }
+            },
+            {
+                'validate': {
+                    'data': {
+                        'value': {'Value': 63}
+                    },
+                    'checks': {
+                        'path': '%sname=num-resources' % base_str
+                    }
+                }
+            },
+            {
+                'validate': {
+                    'data': {
+                        'value': {'Value': 6.3}
+                    },
+                    'checks': {
+                        'path': '%sname=avg-resources-per-node' % base_str
+                    }
+                }
+            }
+        ]
+    }
+    dbquery = MockDbQuery(query_data)
+    mocker.patch.object(app.puppetdb, '_query', side_effect=dbquery.get)
+    rv = client.get('/%2A/')
+
+    soup = BeautifulSoup(rv.data, 'html.parser')
+    assert soup.title.contents[0] == 'Puppetboard'
+    vals = soup.find_all('h1',
+                         {"class": "ui header darkblue no-margin-bottom"})
+
+    assert len(vals) == 3
+    assert vals[0].string == '10'
+    assert vals[1].string == '63'
+    assert vals[2].string == '         6'
+
+    assert rv.status_code == 200
+
+
+def test_index_all_puppetdb_v4(client, mocker,
+                               mock_puppetdb_environments,
+                               mock_puppetdb_default_nodes):
     base_str = 'puppetlabs.puppetdb.population:'
     query_data = {
         'version': [{'version': '4.2.0'}],
         'mbean': [
             {
                 'validate': {
-                    'data': {'Value': '50'},
+                    'data': {'Value': 10},
                     'checks': {
                         'path': '%sname=num-nodes' % base_str
                     }
@@ -136,7 +194,7 @@ def test_index_all(client, mocker,
             },
             {
                 'validate': {
-                    'data': {'Value': '60'},
+                    'data': {'Value': 63},
                     'checks': {
                         'path': '%sname=num-resources' % base_str
                     }
@@ -144,7 +202,7 @@ def test_index_all(client, mocker,
             },
             {
                 'validate': {
-                    'data': {'Value': 60.3},
+                    'data': {'Value': 6.3},
                     'checks': {
                         'path': '%sname=avg-resources-per-node' % base_str
                     }
@@ -162,23 +220,23 @@ def test_index_all(client, mocker,
                          {"class": "ui header darkblue no-margin-bottom"})
 
     assert len(vals) == 3
-    assert vals[0].string == '50'
-    assert vals[1].string == '60'
-    assert vals[2].string == '        60'
+    assert vals[0].string == '10'
+    assert vals[1].string == '63'
+    assert vals[2].string == '         6'
 
     assert rv.status_code == 200
 
 
-def test_index_all_older_puppetdb(client, mocker,
-                                  mock_puppetdb_environments,
-                                  mock_puppetdb_default_nodes):
+def test_index_all_puppetdb_v3(client, mocker,
+                               mock_puppetdb_environments,
+                               mock_puppetdb_default_nodes):
     base_str = 'puppetlabs.puppetdb.population:type=default,'
     query_data = {
         'version': [{'version': '3.2.0'}],
         'mbean': [
             {
                 'validate': {
-                    'data': {'Value': '50'},
+                    'data': {'Value': 10},
                     'checks': {
                         'path': '%sname=num-nodes' % base_str
                     }
@@ -186,7 +244,7 @@ def test_index_all_older_puppetdb(client, mocker,
             },
             {
                 'validate': {
-                    'data': {'Value': '60'},
+                    'data': {'Value': 60},
                     'checks': {
                         'path': '%sname=num-resources' % base_str
                     }
@@ -194,7 +252,7 @@ def test_index_all_older_puppetdb(client, mocker,
             },
             {
                 'validate': {
-                    'data': {'Value': 60.3},
+                    'data': {'Value': 6.3},
                     'checks': {
                         'path': '%sname=avg-resources-per-node' % base_str
                     }
@@ -212,9 +270,9 @@ def test_index_all_older_puppetdb(client, mocker,
                          {"class": "ui header darkblue no-margin-bottom"})
 
     assert len(vals) == 3
-    assert vals[0].string == '50'
+    assert vals[0].string == '10'
     assert vals[1].string == '60'
-    assert vals[2].string == '        60'
+    assert vals[2].string == '         6'
 
     assert rv.status_code == 200
 
@@ -316,6 +374,64 @@ def test_radiator_view(client, mocker,
 def test_radiator_view_all(client, mocker,
                            mock_puppetdb_environments,
                            mock_puppetdb_default_nodes):
+    # starting with v6.9.1 they changed the metric API to v2
+    # and a totally different format
+    base_str = 'puppetlabs.puppetdb.population:'
+    query_data = {
+        'version': [{'version': '6.9.1'}],
+        'metrics': [
+            {
+                'validate': {
+                    'data': {
+                        'value': {'Value': '50'}
+                    },
+                    'checks': {
+                        'path': '%sname=num-nodes' % base_str
+                    }
+                }
+            },
+            {
+                'validate': {
+                    'data': {
+                        'value': {'Value': '60'}
+                    },
+                    'checks': {
+                        'path': '%sname=num-resources' % base_str
+                    }
+                }
+            },
+            {
+                'validate': {
+                    'data': {
+                        'value': {'Value': 60.3}
+                    },
+                    'checks': {
+                        'path': '%sname=avg-resources-per-node' % base_str
+                    }
+                }
+            }
+        ]
+    }
+
+    dbquery = MockDbQuery(query_data)
+
+    mocker.patch.object(app.puppetdb, '_query', side_effect=dbquery.get)
+
+    rv = client.get('/%2A/radiator')
+
+    assert rv.status_code == 200
+
+    soup = BeautifulSoup(rv.data, 'html.parser')
+    assert soup.title.contents[0] == 'Puppetboard'
+    assert soup.h1 != 'Not Found'
+    total = soup.find(class_='total')
+
+    assert '50' in total.text
+
+
+def test_radiator_view_all_v4(client, mocker,
+                              mock_puppetdb_environments,
+                              mock_puppetdb_default_nodes):
     base_str = 'puppetlabs.puppetdb.population:'
     query_data = {
         'version': [{'version': '4.2.0'}],
@@ -363,9 +479,9 @@ def test_radiator_view_all(client, mocker,
     assert '50' in total.text
 
 
-def test_radiator_view_all_old_version(client, mocker,
-                                       mock_puppetdb_environments,
-                                       mock_puppetdb_default_nodes):
+def test_radiator_view_all_v3(client, mocker,
+                              mock_puppetdb_environments,
+                              mock_puppetdb_default_nodes):
     base_str = 'puppetlabs.puppetdb.population:type=default,'
     query_data = {
         'version': [{'version': '3.2.0'}],
@@ -830,6 +946,199 @@ def test_offline_static(client):
     assert rv.status_code == 200
 
 
+def test_health_status(client):
+    rv = client.get('/status')
+
+    assert rv.status_code == 200
+    assert rv.data.decode('utf-8') == 'OK'
+
+
+def test_metric_params_691():
+    query_type, metric_version = app.metric_params((6, 9, 1))
+    assert query_type == ''
+    assert metric_version == 'v2'
+
+    query_type, metric_version = app.metric_params((6, 9, 0))
+    assert query_type == ''
+    assert metric_version == 'v1'
+
+
+def test_metric_params_320():
+    query_type, metric_version = app.metric_params((3, 2, 0))
+    assert query_type == 'type=default,'
+    assert metric_version == 'v1'
+
+    query_type, metric_version = app.metric_params((4, 0, 0))
+    assert query_type == ''
+    assert metric_version == 'v1'
+
+
+def test_metrics_v2_api(client, mocker,
+                        mock_puppetdb_environments,
+                        mock_puppetdb_default_nodes):
+    # starting with v6.9.1 they changed the metric API to v2
+    # and a totally different format
+    query_data = {
+        'version': [{'version': '6.9.1'}],
+        'metrics-list': [
+            {
+                'validate': {
+                    'data': {
+                        'value': {
+                            'java.lang': {
+                                'type=Memory': {}
+                            },
+                            'puppetlabs.puppetdb.population': {
+                                'name=num-nodes': {}
+                            },
+                        }
+                    },
+                    'checks': {
+                    }
+                }
+            }
+        ]
+    }
+    dbquery = MockDbQuery(query_data)
+    mocker.patch.object(app.puppetdb, '_query', side_effect=dbquery.get)
+    rv = client.get('/metrics')
+
+    soup = BeautifulSoup(rv.data, 'html.parser')
+    assert soup.title.contents[0] == 'Puppetboard'
+    ul_list = soup.find_all('ul', attrs={'class': 'ui list searchable'})
+    assert len(ul_list) == 1
+    vals = ul_list[0].find_all('a')
+
+    assert len(vals) == 2
+    assert vals[0].string == 'java.lang:type=Memory'
+    assert vals[1].string == 'puppetlabs.puppetdb.population:name=num-nodes'
+
+    assert rv.status_code == 200
+
+
+def test_metrics_v1_api(client, mocker,
+                        mock_puppetdb_environments,
+                        mock_puppetdb_default_nodes):
+    query_data = {
+        'version': [{'version': '4.2.0'}],
+        'mbean': [
+            {
+                'validate': {
+                    'data': {
+                        'java.lang:type=Memory': {},
+                        'puppetlabs.puppetdb.population:name=num-nodes': {},
+                    },
+                    'checks': {
+                    }
+                }
+            }
+        ]
+    }
+    dbquery = MockDbQuery(query_data)
+    mocker.patch.object(app.puppetdb, '_query', side_effect=dbquery.get)
+    rv = client.get('/metrics')
+
+    soup = BeautifulSoup(rv.data, 'html.parser')
+    assert soup.title.contents[0] == 'Puppetboard'
+    ul_list = soup.find_all('ul', attrs={'class': 'ui list searchable'})
+    assert len(ul_list) == 1
+    vals = ul_list[0].find_all('a')
+
+    assert len(vals) == 2
+    assert vals[0].string == 'java.lang:type=Memory'
+    assert vals[1].string == 'puppetlabs.puppetdb.population:name=num-nodes'
+
+    assert rv.status_code == 200
+
+
+def test_metric_v2_api(client, mocker,
+                       mock_puppetdb_environments,
+                       mock_puppetdb_default_nodes):
+    # starting with v6.9.1 they changed the metric API to v2
+    # and a totally different format
+    metric_name = 'puppetlabs.puppetdb.population:name=num-nodes'
+    query_data = {
+        'version': [{'version': '6.9.1'}],
+        'metrics': [
+            {
+                'validate': {
+                    'data': {
+                        'value': {'Value': 50},
+                    },
+                    'checks': {
+                        'path': metric_name,
+                    }
+                }
+            }
+        ]
+    }
+    dbquery = MockDbQuery(query_data)
+    mocker.patch.object(app.puppetdb, '_query', side_effect=dbquery.get)
+    rv = client.get('/metric/' + metric_name)
+
+    soup = BeautifulSoup(rv.data, 'html.parser')
+    assert soup.title.contents[0] == 'Puppetboard'
+
+    small_list = soup.find_all('small')
+    assert len(small_list) == 1
+    assert small_list[0].string == metric_name
+
+    tbody_list = soup.find_all('tbody')
+    assert len(tbody_list) == 1
+    rows = tbody_list[0].find_all('tr')
+
+    assert len(rows) == 1
+    cols = rows[0].find_all('td')
+    assert len(cols) == 2
+    assert cols[0].string == 'Value'
+    assert cols[1].string == '50'
+
+    assert rv.status_code == 200
+
+
+def test_metric_v1_api(client, mocker,
+                       mock_puppetdb_environments,
+                       mock_puppetdb_default_nodes):
+    metric_name = 'puppetlabs.puppetdb.population:name=num-nodes'
+    query_data = {
+        'version': [{'version': '4.2.0'}],
+        'mbean': [
+            {
+                'validate': {
+                    'data': {'Value': 50},
+                    'checks': {
+                        'path': metric_name,
+                    }
+                }
+            }
+        ]
+    }
+    dbquery = MockDbQuery(query_data)
+    mocker.patch.object(app.puppetdb, '_query', side_effect=dbquery.get)
+    rv = client.get('/metric/' + metric_name)
+
+    soup = BeautifulSoup(rv.data, 'html.parser')
+    assert soup.title.contents[0] == 'Puppetboard'
+
+    small_list = soup.find_all('small')
+    assert len(small_list) == 1
+    assert small_list[0].string == metric_name
+
+    tbody_list = soup.find_all('tbody')
+    assert len(tbody_list) == 1
+    rows = tbody_list[0].find_all('tr')
+
+    assert len(rows) == 1
+    cols = rows[0].find_all('td')
+    assert len(cols) == 2
+    assert cols[0].string == 'Value'
+    assert cols[1].string == '50'
+
+    assert rv.status_code == 200
+
+
+# Running this test at the end because it changes the global state of the app
+# throwing off other tests if this one fails
 def test_custom_title(client, mocker,
                       mock_puppetdb_environments,
                       mock_puppetdb_default_nodes):
@@ -847,10 +1156,3 @@ def test_custom_title(client, mocker,
     rv = client.get('/')
     soup = BeautifulSoup(rv.data, 'html.parser')
     assert soup.title.contents[0] == custom_title
-
-
-def test_health_status(client):
-    rv = client.get('/status')
-
-    assert rv.status_code == 200
-    assert rv.data.decode('utf-8') == 'OK'


### PR DESCRIPTION
Tried using the latest version of `puppetboard` against the recently released PuppetDB 6.9.1 and ran into several problems related to them disabling the metrics/v1 endpoint (https://puppet.com/security/cve/CVE-2020-7943/) along with the bug fixes for metrics/v2 that were recently merged.

**Fixes**
- In Metrics v2 the `avg-resources-per-node` metric now returns a string in the format `1234/11` (`<total_resources>/<num_nodes>`). This displayed funny on the UI and was not consistent with previous behavior. To fix this i reverted back to computing the average resources per node as we were doing with metrics v1.
- In Metrics v2 the way you list all available metrics as done in the Metrics page changed. This page failed to load on the latest version. To support these changes i needed to update `pypuppetdb` (PR: https://github.com/voxpupuli/pypuppetdb/pull/175). We also had to do some data manipulation on the back end because the formatting of the response changed in PuppetDB.

**TODO**
- [x] Merge in pypuppetdb pr: https://github.com/voxpupuli/pypuppetdb/pull/175
- [x] Updated `requirements.txt` with new pypuppetdb version