### PR TITLE
Adjust metrics API for Puppet Server 5.3.x

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -84,8 +84,10 @@ def check_env(env, envs):
 def metric_params(db_version):
     query_type = ''
 
-    # PuppetDB moved to a new metrics API (v2) in 6.9.1
-    if db_version > (6, 9, 0):
+    # Puppet Server is enforcing new metrics API (v2)
+    # starting with versions 6.9.1 and 5.3.12
+    if (db_version > (6, 9, 0) or
+            (db_version > (5, 3, 11) and db_version < (6, 0, 0))):
         metric_version = 'v2'
     else:
         metric_version = 'v1'

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -953,6 +953,16 @@ def test_health_status(client):
     assert rv.data.decode('utf-8') == 'OK'
 
 
+def test_metric_params_5312():
+    query_type, metric_version = app.metric_params((5, 3, 12))
+    assert query_type == ''
+    assert metric_version == 'v2'
+
+    query_type, metric_version = app.metric_params((5, 3, 11))
+    assert query_type == ''
+    assert metric_version == 'v1'
+
+
 def test_metric_params_691():
     query_type, metric_version = app.metric_params((6, 9, 1))
     assert query_type == ''


### PR DESCRIPTION
Puppet Server releases done on 10 March 2020 forcefully disabled the metrics v1 endpoints. The appropriate change was made for Puppet Server 6.9.1 support, however Puppet Server 5.3.12 also needs the same treatment.

Although everyone is urged to upgrade when possible, in case someone wants to use Puppetboard and has not upgraded yet, we should support them, as the ['Puppet packages and versions'](https://puppet.com/docs/puppet/latest/about_agent.html#puppet-releases-and-lifecycle) docs page currently states that Puppet 5.5.x (Puppet Server 5.3.x) is expected to become EOL in November 2020.

Ref: #553, #555