### PR TITLE
python3.5 (#551): add python 3.5 back to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: xenial
 language: python
 python:
+  - 3.5
   - 3.6
   - 3.7
   - &latest_py3 3.8

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ As of version 0.1.0 and higher, Puppetboard **requires** PuppetDB 3. Version 0.3
 
 At the current time of writing, Puppetboard supports the following Python versions:
 
+* Python 3.5
 * Python 3.6
 * Python 3.7
 * Python 3.8

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
This PR reverts [some off] #531 to support for python3.5 back to the test matrix.

closes #551