### PR TITLE
Puppet DB 5.2.13 requires v2 metrics

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -85,9 +85,10 @@ def metric_params(db_version):
     query_type = ''
 
     # Puppet Server is enforcing new metrics API (v2)
-    # starting with versions 6.9.1 and 5.3.12
+    # starting with versions 6.9.1, 5.3.12, and 5.2.13
     if (db_version > (6, 9, 0) or
-            (db_version > (5, 3, 11) and db_version < (6, 0, 0))):
+            (db_version > (5, 3, 11) and db_version < (6, 0, 0)) or
+            (db_version > (5, 2, 12) and db_version < (5, 3, 10))):
         metric_version = 'v2'
     else:
         metric_version = 'v1'

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -953,6 +953,16 @@ def test_health_status(client):
     assert rv.data.decode('utf-8') == 'OK'
 
 
+def test_metric_params_5213():
+    query_type, metric_version = app.metric_params((5, 2, 13))
+    assert query_type == ''
+    assert metric_version == 'v2'
+
+    query_type, metric_version = app.metric_params((5, 2, 12))
+    assert query_type == ''
+    assert metric_version == 'v1'
+
+
 def test_metric_params_5312():
     query_type, metric_version = app.metric_params((5, 3, 12))
     assert query_type == ''


### PR DESCRIPTION
Puppet is now forcing the v2 metrics endpoint in PuppetDB 5.2.13.