### PR TITLE
Surround multiline messages with <pre> in reports

### DIFF
--- a/puppetboard/templates/report.html
+++ b/puppetboard/templates/report.html
@@ -77,7 +77,11 @@
         <td rel="utctimestamp">{{log.time}}</td>
         <td>{{log.source}}</td>
         <td>{{log.tags|join(', ')}}</td>
-        <td>{{log.message}}</td>
+        {% if '\n' in log.message %}
+          <td><pre>{{log.message}}</pre></td>
+        {% else %}
+          <td>{{log.message}}</td>
+        {% endif %}
         {% if log.file != None and log.line != None %}
           <td>{{log.file}}:{{log.line}}</td>
         {% else %}


### PR DESCRIPTION
Currently puppetboard shows multiline messages (code diffs) on a single line as a part of the report, which makes it very difficult to read changed lines from the diff. This PR makes browsers preserve newlines in messages.

This pull request fills the same purpose as #408 but it doesn't decrease test coverage. It also makes diffs show up as monospace, which makes code changes easier to read.