### PR TITLE
Fix CI builds by requiring pytest >= 4.6

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 pep8
 coverage
 mock
-pytest
+pytest >=4.6
 pytest-pep8
 pytest-cov
 pytest-mock


### PR DESCRIPTION
Travis's default python archive for python < 3.8 includes pytest 4.1, which does not match the requirements of the latest pytest-cov (v2.8.1). This has caused recent CI builds (#575, #576) to fail.