### PR TITLE
Remove Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
   - &latest_py3 3.8

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ As of version 0.1.0 and higher, Puppetboard **requires** PuppetDB 3. Version 0.3
 
 At the current time of writing, Puppetboard supports the following Python versions:
 
-* Python 3.5
 * Python 3.6
 * Python 3.7
 * Python 3.8

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
The support of Python 3.5 ended at September 2020, so we should drop it from the test matrix