### PR TITLE
Convert Boolean Parameters to boolean for puppetdb query

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -9,6 +9,7 @@ except ImportError:
     from urllib import unquote, unquote_plus, quote_plus  # type: ignore
 from datetime import datetime, timedelta
 from itertools import tee
+from distutils.util import strtobool
 import sys
 from flask import (
     render_template, abort, url_for,
@@ -24,7 +25,7 @@ from pypuppetdb.QueryBuilder import (ExtractOperator, AndOperator,
 
 from puppetboard.forms import ENABLED_QUERY_ENDPOINTS, QueryForm
 from puppetboard.utils import (get_or_abort, yield_or_stop,
-                               get_db_version)
+                               get_db_version, is_bool)
 from puppetboard.dailychart import get_daily_reports_chart
 
 try:
@@ -721,7 +722,10 @@ def fact_ajax(env, node, fact, value):
         value = int(value)
     except ValueError:
         if value is not None and query is not None:
-            query.add(EqualsOperator('value', unquote_plus(value)))
+            if is_bool(value):
+                query.add(EqualsOperator('value', bool(strtobool(value))))
+            else:
+                query.add(EqualsOperator('value', unquote_plus(value)))
     except TypeError:
         pass
 

--- a/puppetboard/utils.py
+++ b/puppetboard/utils.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import json
 import logging
 import os.path
+from distutils.util import strtobool
 
 from flask import abort, request, url_for
 from jinja2.utils import contextfunction
@@ -120,3 +121,15 @@ def yield_or_stop(generator):
             yield next(generator)
         except (EmptyResponseError, ConnectionError, HTTPError, StopIteration):
             return
+
+
+def is_bool(b):
+    try:
+        bool(strtobool(b))
+        return True
+    except ValueError:
+        return False
+    except TypeError:
+        return False
+    except AttributeError:
+        return False

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -217,3 +217,30 @@ def test_stop_http_error():
     gen = utils.yield_or_stop(my_generator())
     for val in gen:
         assert 1 == val
+
+
+def test_is_bool_false():
+    test_values = [
+        "Test",
+        "SomeWrongData",
+        2,
+        2.0,
+        -5
+    ]
+
+    for test_value in test_values:
+        assert utils.is_bool(test_value) is False
+
+
+def test_is_bool_true():
+    test_values = [
+        "True",
+        "true",
+        "False",
+        "false",
+        "1",
+        "0"
+    ]
+
+    for test_value in test_values:
+        assert utils.is_bool(test_value) is True


### PR DESCRIPTION
A PuppetDB Query with a Boolean Parameter must not be in quotes. This PR fix this issue and resolves #583 