### PR TITLE
travis: Test on Ubuntu 20.04 Focal instead of Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 language: python
 python:
   - 3.6


### PR DESCRIPTION
Move from Ubuntu Xenial 18.04 to Ubuntu Focal 20.04