### PR TITLE
Improve facts columns balancing

### DIFF
--- a/test/test_app.py
+++ b/test/test_app.py
@@ -769,7 +769,7 @@ def test_facts_view_empty_when_no_facts(client,
 
     searchable = soup.find('div', {'class': 'searchable'})
     vals = searchable.find_all('div', {'class': 'column'})
-    assert len(vals) == 1
+    assert len(vals) == 0
 
 
 def test_fact_view_with_graph(client, mocker,


### PR DESCRIPTION
Grouping facts by first letter is inefficient when a lot of facts begin
with some specific letters.  E.g. with multiple network interfaces.

Before:
![Before](https://user-images.githubusercontent.com/148721/113811095-4863d700-9707-11eb-9c59-5d9fdca598ef.png)

After:
![Screenshot_2021-04-06 Puppetboard(1After)](https://user-images.githubusercontent.com/148721/113811106-4bf75e00-9707-11eb-8267-76d925563b4a.png)
