### PR TITLE
Pypuppetdb 2.4.0 & Python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for the open source Puppet.
 ## Requirements
 
 * PuppetDB v. 3.0-6.0 (it may work with newer but this has not been verified)
-* Python 3.6/3.7/3.8
+* Python 3.6 / 3.7 / 3.8 / 3.9
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ MarkupSafe >=1.1.1,<2
 WTForms >=2.2.1,<3
 Werkzeug >=0.16.0,<1
 itsdangerous >=1.1.0,<2
-pypuppetdb >=2.1.0,<3
+pypuppetdb>=2.4.0.rc1,<3
 requests >=2.22.0,<3
 CommonMark==0.9.1

--- a/setup.py
+++ b/setup.py
@@ -70,5 +70,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}
+envlist = py{36,37,38,39}
 
 [testenv]
 deps=
@@ -7,4 +7,4 @@ deps=
     bandit
 commands=
     py.test --cov=puppetboard --pep8 -v
-    py{36,37,38}: bandit -r puppetboard
+    py{36,37,38,39}: bandit -r puppetboard


### PR DESCRIPTION
Pypuppetdb 2.4.0.rc1 is a pretty big new release. It contains some big refactoring and reorganization of the code. It should not break backward compatibility but with such amount of changes it needs more testing before a final release. See https://github.com/voxpupuli/pypuppetdb/pull/201 for more info.

Therefore let's test it - by the volunteers only, of course - in a pre-release of Puppeboard. See #620.