### PR TITLE
Add a sample settings.py

### DIFF
--- a/settings.py.sample
+++ b/settings.py.sample
@@ -1,0 +1,20 @@
+# PuppetBoard configuration file
+#
+# You can tune PuppetBoard by editing this file and running PuppetBoard with
+# the environment variable PUPPETBOARD_SETTINGS containing the path to this
+# file.
+#
+# Please refer to the following URL for a list of available variables:
+# https://github.com/voxpupuli/puppetboard#app-settings
+#
+# If you are not accessing PuppetDB locally, set the following variables:
+#
+# PUPPETDB_HOST = 'localhost'
+# PUPPETDB_PORT = 8080
+#
+# If you access PuppetDB over TLS, configure the path to the TLS certifcate,
+# key and CA certificate bellow:
+#
+# PUPPETDB_CERT = ''
+# PUPPETDB_KEY = ''
+# PUPPETDB_SSL_VERIFY = ''


### PR DESCRIPTION
This file is mostly useful when packaging PuppetBoard and providing a
sample configuration file with pointers to the documentation and some
kind of "well-known" location for such a file on the puppet-puppetboard
module side.

This is step 1 of the process described in https://github.com/voxpupuli/puppet-puppetboard/pull/329#issuecomment-886096120