### PR TITLE
Enumerate FreeBSD package

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ docker build -t puppetboard .
 
 Actively maintained packages:
 
+* [FreeBSD](https://www.freshports.org/www/py-puppetboard/)
 * [OpenBSD](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/www/puppetboard/)
   maintained by [Sebastian Reitenbach](https://github.com/buzzdeee)
 


### PR DESCRIPTION
PupeptBoard is available as a package on FreeBSD.  Support for managing
PupeptBoard using system packages is WIP in puppet-puppetboard.