### PR TITLE
Fix getting nodes with non-string fact values

### DIFF
--- a/puppetboard/utils.py
+++ b/puppetboard/utils.py
@@ -1,7 +1,7 @@
+import ast
 import json
 import logging
 import os.path
-from distutils.util import strtobool
 
 from flask import abort, request, url_for
 from jinja2.utils import contextfunction
@@ -52,6 +52,18 @@ def get_db_version(puppetdb):
     except EmptyResponseError as e:
         log.error(str(e))
     return ver
+
+
+def parse_python(value: str):
+    """
+    :param value: any string, number, bool, list or a dict
+                  casted to a string (f.e. "{'up': ['eth0'], (...)}")
+    :return: the same value but with a proper type
+    """
+    try:
+        return ast.literal_eval(value)
+    except ValueError:
+        return str(value)
 
 
 def formatvalue(value):
@@ -121,15 +133,3 @@ def yield_or_stop(generator):
             yield next(generator)
         except (EmptyResponseError, ConnectionError, HTTPError, StopIteration):
             return
-
-
-def is_bool(b):
-    try:
-        bool(strtobool(b))
-        return True
-    except ValueError:
-        return False
-    except TypeError:
-        return False
-    except AttributeError:
-        return False

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -228,30 +228,3 @@ def test_stop_http_error():
     gen = utils.yield_or_stop(my_generator())
     for val in gen:
         assert 1 == val
-
-
-def test_is_bool_false():
-    test_values = [
-        "Test",
-        "SomeWrongData",
-        2,
-        2.0,
-        -5
-    ]
-
-    for test_value in test_values:
-        assert utils.is_bool(test_value) is False
-
-
-def test_is_bool_true():
-    test_values = [
-        "True",
-        "true",
-        "False",
-        "false",
-        "1",
-        "0"
-    ]
-
-    for test_value in test_values:
-        assert utils.is_bool(test_value) is True


### PR DESCRIPTION
Examples:
* int (in this case the filtering did not occur at all
and ALL results were returned),
* list of dict (here the filtering was not done and
ZERO results were returned),

Fixes #612.