### PR TITLE
Format structured fact values as pretty-printed, colored JSON

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -12,6 +12,7 @@ from flask import (
 
 import logging
 import json
+from json import dumps
 
 from pypuppetdb.QueryBuilder import (ExtractOperator, AndOperator,
                                      EqualsOperator, FunctionOperator,
@@ -792,18 +793,23 @@ def fact_ajax(env, node, fact, value):
         if not fact:
             line.append(fact_h.name)
         if not node:
-            line.append('<a href="{0}">{1}</a>'.format(
-                url_for('node', env=env, node_name=fact_h.node),
-                fact_h.node))
+            if value:
+                line.append('["{0}", "{1}"]'.format(
+                    url_for('node', env=env, node_name=fact_h.node),
+                    fact_h.node))
+            else:
+                line.append('<a href="{0}">{1}</a>'.format(
+                    url_for('node', env=env, node_name=fact_h.node),
+                    fact_h.node))
         if not value:
             fact_value = fact_h.value
             if isinstance(fact_value, str):
                 fact_value = quote_plus(fact_h.value)
 
-            line.append('<a href="{0}">{1}</a>'.format(
+            line.append('["{0}", {1}]'.format(
                 url_for(
                     'fact', env=env, fact=fact_h.name, value=fact_value),
-                fact_h.value))
+                dumps(fact_h.value)))
 
         json['data'].append(line)
 

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -189,3 +189,33 @@ h1.ui.header.no-margin-bottom {
 #dailyReportsChartContainer {
   height: 160px;
 }
+
+pre {
+  padding: 0;
+  margin: 0;
+  font-family: "Open Sans", sans-serif;
+}
+.string {
+  color: #2E5D8C;
+}
+.string:hover {
+  color: #1e70bf;
+}
+.number {
+  color: darkorange;
+}
+.number:hover {
+  color: #ffab3d;
+}
+.boolean {
+  color: blue;
+}
+.boolean:hover {
+  color: #7171fc;
+}
+.key {
+  color: rgb(97, 117, 54);
+}
+.null {
+  color: magenta;
+}

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -62,16 +62,52 @@
     "order": [[ 0, "desc" ]],
     {% endif -%}
    // Rendering - add rendering options for columns
-    "columnDefs": [ {
+    "columnDefs": [
+    {% if table_html_id == 'facts_table' -%}
+    { "width": "65%", "targets": -1 },
+    {% endif -%}
+    {
       "targets": -1,
       "data:": null,
       "render": function (data, type, full, meta) {
-       shorta = data.toString().replace(/[{},]/g, "<br />");
-       shortb = shorta.replace(/u'/g, " "); 
-       shortc = shortb.replace(/'/g, " "); 
-       return shortc;
-       }}],
-      // Custom options
+        data = JSON.parse(data)
+
+        url = data[0]
+        json_to_show = data[1]
+
+        if (Object.prototype.toString.call(json_to_show) === "[object String]") {
+            // Print plain string as-is to avoid making it surrounded with ""
+            json_to_show = '<span class="string">' + json_to_show + '</span>';
+        } else {
+            // Pretty-print of JSON, with syntax highlight
+            // Based on https://stackoverflow.com/a/7220510/2693875
+
+            json_to_show = JSON.stringify(json_to_show, null, 4); // spacing level = 4
+            json_to_show = json_to_show.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            json_to_show = json_to_show.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function (match) {
+                var cls = 'number';
+                if (/^"/.test(match)) {
+                    if (/:$/.test(match)) {
+                        cls = 'key';
+                    } else {
+                        cls = 'string';
+                    }
+                } else if (/true|false/.test(match)) {
+                    cls = 'boolean';
+                } else if (/null/.test(match)) {
+                    cls = 'null';
+                }
+                return '<span class="' + cls + '">' + String(match) + '</span>';
+            });
+
+            // Add pre tag for indentation to be visible
+            json_to_show = '<pre>' + json_to_show + '</pre>'
+        }
+
+        return '<a href="' + url + '">' + json_to_show + '</a>'
+      }
+    }],
+    // Custom options
     {% if extra_options %}{% call extra_options() %}Callback to parent defined options{% endcall %}{% endif %}
   });
 


### PR DESCRIPTION
and extend the width of the fact values column in the node
view as the values are usually longer that the names.

The colors mean:
* orange - number,
* green - dict's key name,
* blue - boolean,
* magenta - null (not sure if this will be used at all as null facts are not pushed to puppetdb, are they?),

Note: the downside of using JSON in JS code is that float numbers with 0 decimal numbers, f.e. `2.0`, are shown like they are ints, f.e.`2`.