### PR TITLE
PyPI package adds missing fonts and icons

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md
 include CHANGELOG.md
 include LICENSE
-recursive-include puppetboard/static *.css *.js *icons.* Open_Sans.woff
+recursive-include puppetboard/static *.css *.js *icons.* Open_Sans.woff *.ttf *.ico *.svg
 recursive-include puppetboard/templates *
 include requirements*.txt


### PR DESCRIPTION
Add the following files to the pypi package ：

puppetboard/static/favicon.ico
puppetboard/static/favicon.svg
puppetboard/static/fonts/Cousine-Regular.ttf
puppetboard/static/fonts/lato-italic-400.ttf
puppetboard/static/fonts/lato-italic-700.ttf
puppetboard/static/fonts/lato-normal-400.ttf
puppetboard/static/fonts/lato-normal-700.ttf