### PR TITLE
Support passing puppetdb certificates via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ supply the following settings:
 -   `PUPPETDB_KEY = /path/to/private/keyfile.pem`
 -   `PUPPETDB_CERT = /path/to/public/keyfile.crt`
 
+When using the Puppetboard Docker image, you may also pass Puppetboard it's certificate contents via these environment
+variables, either as a multiline string or pre-base64 encoded. This can be useful where the certificate is stored in a
+secrets store i.e. AWS SSM Parameter Store.
+
+```
+PUPPETDB_CERT="-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----"
+```
+
+```
+PUPPETDB_CERT=LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQouLi4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+```
+
 For information about how to generate the correct keys please refer to the 
 [pypuppetdb documentation](https://pypuppetdb.readthedocs.io/en/latest/connecting.html#ssl). Alternatively it is possible
 to explicitly specify the protocol to be used setting the `PUPPETDB_PROTO` variable.

--- a/test/test_docker_settings.py
+++ b/test/test_docker_settings.py
@@ -64,6 +64,18 @@ def test_cert_path(cleanup_env):
     assert docker_settings.PUPPETDB_SSL_VERIFY == ca_file
 
 
+def test_cert_to_file(cleanup_env):
+    import tempfile
+    cert_string = '-----BEGIN CERTIFICATE-----\nMIIFkjCCA3qgAwIB'
+
+    os.environ['PUPPETDB_KEY'] = cert_string
+    reload(docker_settings)
+    assert docker_settings.PUPPETDB_KEY.startswith(tempfile.gettempdir())
+
+    # Clean up the generated file
+    os.unlink(docker_settings.PUPPETDB_KEY)
+
+
 def validate_facts(facts):
     assert isinstance(facts, list)
     assert len(facts) > 0

--- a/test/test_docker_settings.py
+++ b/test/test_docker_settings.py
@@ -66,11 +66,29 @@ def test_cert_path(cleanup_env):
 
 def test_cert_to_file(cleanup_env):
     import tempfile
-    cert_string = '-----BEGIN CERTIFICATE-----\nMIIFkjCCA3qgAwIB'
+    cert_string = '-----BEGIN CERTIFICATE-----\nMIIFkjCCA3qgAwf'
 
     os.environ['PUPPETDB_KEY'] = cert_string
     reload(docker_settings)
     assert docker_settings.PUPPETDB_KEY.startswith(tempfile.gettempdir())
+
+    with open(docker_settings.PUPPETDB_KEY) as test_cert_file:
+        assert test_cert_file.read() == '-----BEGIN CERTIFICATE-----\nMIIFkjCCA3qgAwf'
+
+    # Clean up the generated file
+    os.unlink(docker_settings.PUPPETDB_KEY)
+
+
+def test_cert_to_file_base64(cleanup_env):
+    import tempfile
+    cert_string = 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZrakNDQTNxZ0F3SUI='
+
+    os.environ['PUPPETDB_KEY'] = cert_string
+    reload(docker_settings)
+    assert docker_settings.PUPPETDB_KEY.startswith(tempfile.gettempdir())
+
+    with open(docker_settings.PUPPETDB_KEY) as test_cert_file:
+        assert test_cert_file.read() == '-----BEGIN CERTIFICATE-----\nMIIFkjCCA3qgAwIB'
 
     # Clean up the generated file
     os.unlink(docker_settings.PUPPETDB_KEY)


### PR DESCRIPTION
Closes https://github.com/voxpupuli/puppetboard/issues/669

Adds support for passing certificates and keys to the following environment variables:
* PUPPETDB_SSL_VERIFY
* PUPPETDB_KEY
* PUPPETDB_CERT

I have tested this in my own environment as per the issue. With the container running in AWS Fargate, certificates being passed as env vars from AWS SSM Parameter store.

I had ran into a couple edge cases where the shell was breaking the new lines. These feel like general environment variable edge cases and not so much an issue with this code.