### PR TITLE
Fix auto-resize in radiator view

### DIFF
--- a/puppetboard/templates/radiator.html
+++ b/puppetboard/templates/radiator.html
@@ -7,9 +7,9 @@
     {% endif %}
     <link href="{{ url_for('static', filename='css/radiator.css')}}" media="screen" rel="stylesheet" type="text/css" />
     {% if config.OFFLINE_MODE %}
-        <script src="{{ url_for('static', filename='jquery-3.5.1/jquery.min.js') }}"></script>
+        <script src="{{ url_for('static', filename='jquery-3.6.0/jquery.min.js') }}"></script>
     {% else %}
-        <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     {% endif %}
     <script src="{{ url_for('static', filename='js/radiator.js')}}" type="text/javascript"></script>
 </head>


### PR DESCRIPTION
This fixes the links to jquery again.
See also https://github.com/voxpupuli/puppetboard/commit/af87dc207e1eddf80d3df36ec1862568ecfb00c4 (for previous instance) https://github.com/voxpupuli/puppetboard/pull/654 (for regression introduction)