### PR TITLE
Remove border-radius from Top Menu

### DIFF
--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -112,6 +112,7 @@ h1.ui.header.no-margin-bottom {
 
 .ui.menu.darkblue {
   background-color: #2C3E50;
+  border-radius: 0px !important;
 }
 
 .ui.darkblue.header, i.darkblue {


### PR DESCRIPTION
From a user experience perspective, it would make sense to remove the `border-radius` which is added by `semantic.min.css` and thus make the top navigation appear more clearly anchored to the page. 