### PR TITLE
Improve UI of the environment selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,11 @@ For information about how to generate the correct keys please refer to the
 [pypuppetdb documentation](https://pypuppetdb.readthedocs.io/en/latest/connecting.html#ssl). Alternatively it is possible
 to explicitly specify the protocol to be used setting the `PUPPETDB_PROTO` variable.
 
-Other settings that might be interesting in no particular order:
+Other settings that might be interesting, in no particular order:
 
+- `FAVORITE_ENVS`: an ordered list of Puppet environment names that will be shown immediately after "All Environments"
+    and before other environments (which are sorted by name) in the dropdown for choosing the environment shown
+    in the top-right of the UI. Environments listed here that do not really exist in your deployment are silently ignored.
 - `SHOW_ERROR_AS`: `friendly` or `raw`. The former makes Puppet run errors in Report and Failures views shown
     in a modified, (arguably) more user-friendly form. The latter shows them as they are.
     Defaults to `friendly`.

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -59,5 +59,6 @@ FAVORITE_ENVS = [
     'production',
     'staging',
     'qa',
+    'test',
     'dev',
 ]

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -53,6 +53,11 @@ REFRESH_RATE = 30
 DAILY_REPORTS_CHART_ENABLED = True
 DAILY_REPORTS_CHART_DAYS = 8
 WITH_EVENT_NUMBERS = True
-
 SHOW_ERROR_AS = 'friendly'  # or 'raw'
 CODE_PREFIX_TO_REMOVE = '/etc/puppetlabs/code/environments(/.*?/modules)?'
+FAVORITE_ENVS = [
+    'production',
+    'staging',
+    'qa',
+    'dev',
+]

--- a/puppetboard/docker_settings.py
+++ b/puppetboard/docker_settings.py
@@ -128,3 +128,10 @@ WITH_EVENT_NUMBERS = coerce_bool(os.getenv('WITH_EVENT_NUMBERS'), True)
 
 SHOW_ERROR_AS = os.getenv('SHOW_ERROR_AS', 'friendly')
 CODE_PREFIX_TO_REMOVE = os.getenv('CODE_PREFIX_TO_REMOVE', '/etc/puppetlabs/code/environments')
+FAVORITE_ENVS_DEF = ','.join([
+    'production',
+    'staging',
+    'qa',
+    'dev',
+])
+FAVORITE_ENVS = [x.strip() for x in os.getenv('FAVORITE_ENVS', FAVORITE_ENVS_DEF).split(',')]

--- a/puppetboard/errors.py
+++ b/puppetboard/errors.py
@@ -34,7 +34,7 @@ def precond_failed(e):
 
 @app.errorhandler(500)
 def server_error(e):
-    envs = []
+    envs = {}
     try:
         envs = environments()
     except InternalServerError:

--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -6,7 +6,6 @@
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico')}}" sizes="any"/>
     <link rel="icon" href="{{ url_for('static', filename='favicon.svg')}}" type="image/svg+xml"/>
 
-
     {%- filter indent(width=4) %}
     {%- if config.OFFLINE_MODE %}
     {%- include "_static_offline.html" %}
@@ -27,15 +26,25 @@
     <script type="text/javascript">
       {%- block javascript %}{% endblock javascript %}
       $(document).ready(function(){
-          $(".ui.dropdown").dropdown();
-          {% block onload_script %} {% endblock onload_script %}
-        })
+        $(".ui.select-environment").dropdown({
+          match: 'text',
+          ignoreCase: true,
+          selectOnKeydown: false,
+          hideDividers: 'empty',
+          onChange(value) {
+            $(this).addClass('loading')
+            window.location.href = value;
+          }
+        });
+        $(".ui.dropdown:not(.ui.select-environment)").dropdown();
+        {% block onload_script %} {% endblock onload_script %}
+      })
     </script>
     {%- block head %}{% endblock head %}
   </head>
 
   <body>
-    <div class="ui darkblue doubling stackable inverted large menu">
+    <div class="ui darkblue inverted large menu">
       <div class="title item">
         Puppetboard
       </div>
@@ -43,17 +52,22 @@
       <a {% if endpoint == request.endpoint %} class="active item" {% else %} class="item" {% endif %}
         href="{{ url_for(endpoint, env=current_env) }}">{{ caption }}</a>
       {%- endfor %}
-      <div class="ui dropdown item">
-        {{current_env}}
-        <i class="dropdown icon"></i>
-        <div class="menu">
-            <a class="{% if '*' == current_env %}active {% endif %}item" href="{{url_for_field('env', '*')}}">All environments</a>
-          {% for env in envs %}
-            <a class="{% if env == current_env %}active {% endif %}item" href="{{url_for_field('env', env)}}">{{env}}</a>
-          {% endfor %}
+      <div class="right menu">
+        <div class="ui item search very long dropdown selection select-environment">
+          <input type="hidden" name="environment" value="{{ url_for_field('env', current_env) }}">
+          <i class="dropdown icon"></i>
+          <div class="default text">Select Environment</div>
+          <div class="menu">
+            {%- for env_name, env in envs.items() %}
+            {%- if env.divider %}
+            <div class="divider"></div>
+            {%- endif %}
+            <div class="item" data-value="{{env.url}}"><i class="{{env.icon}} icon"></i>{{ env_name }}</div>
+            {%- endfor %}
+          </div>
         </div>
+        <div class="item"><a href="https://github.com/voxpupuli/puppetboard" target="_blank">{{ version() }}</a></div>
       </div>
-      <div class="item right"><a href="https://github.com/voxpupuli/puppetboard" target="_blank">{{ version() }}</a></div>
     </div>
     <div class="ui grid padding-bottom">
       <div class="one wide column"></div>

--- a/puppetboard/utils.py
+++ b/puppetboard/utils.py
@@ -141,6 +141,6 @@ def quote_columns_data(data: str) -> str:
     return data.replace('.', '\\.')
 
 
-def check_env(env, envs):
+def check_env(env: str, envs: dict):
     if env != '*' and env not in envs:
         abort(404)


### PR DESCRIPTION
Hi,

I fixed an old issue which concerns the selection of environments. When you have many environments, display and selection are quite difficult.

I changed the location to the right of the menu and used the Semantic UI select search dropdown to make it easier to search and select.

However I had to add some javascript to do the redirection and css to fix dropdown / loading icon.

The only inconvenience of this solution is that you can no longer right click > open in new tab on an environment.

I tested this fix in the latest chrome and firefox browsers.

Example of the issue :

![puppetboard-environment-issue](https://user-images.githubusercontent.com/813889/179221805-7b09c9d4-44b4-463e-9e36-e6f7b0d0aeff.png)

Results after fix :

![puppetboard-environment-result](https://user-images.githubusercontent.com/813889/179225028-16f5df22-d18a-45c5-88f2-cb0a6b6b3861.png)


