### PR TITLE
Removed error styling from debug lines on report

### DIFF
--- a/puppetboard/templates/report.html
+++ b/puppetboard/templates/report.html
@@ -124,7 +124,7 @@ var logs_table = $('#logs_table').DataTable({
             $(row).addClass('positive');
         } else if (data['level'] == 'warning') {
             $(row).addClass('warning');
-        } else {
+        } else if (data['level'] != 'debug') {
             $(row).addClass('error');
         }
 


### PR DESCRIPTION
Hello,

With many debug messages it becomes difficult to quickly pick out any error messages on a report page. This change removes the 'error' css class from debug rows so that debug level rows are left as white. Open to alternatives. 

Thank you. 