### PR TITLE
Check if fact is None (default for full node view)

### DIFF
--- a/puppetboard/views/facts.py
+++ b/puppetboard/views/facts.py
@@ -47,7 +47,7 @@ def fact_ajax(env, node, fact, value):
     check_env(env, envs)
 
     render_graph = False
-    if fact in app.config['GRAPH_FACTS'] and value is None and node is None:
+    if fact is not None and fact in app.config['GRAPH_FACTS'] and value is None and node is None:
         render_graph = True
 
     query = AndOperator()


### PR DESCRIPTION
Not sure how this ever worked - on a node page, `fact` defaults to `None` and produces this error `TypeError: 'in <string>' requires string as left operand, not NoneType`

Fixes #907