### PR TITLE
Add favicon to radiator

### DIFF
--- a/puppetboard/templates/radiator.html
+++ b/puppetboard/templates/radiator.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
     <title>{{config.PAGE_TITLE}}</title>
+    <link rel="icon" href="{{ url_for('static', filename='favicon.ico')}}" sizes="any"/>
+    <link rel="icon" href="{{ url_for('static', filename='favicon.svg')}}" type="image/svg+xml"/>
     {% if config.REFRESH_RATE > 0 %}
     <meta http-equiv='refresh' content="{{config.REFRESH_RATE}}"/>
     {% endif %}


### PR DESCRIPTION
I see 404 errors in nginx due to the radiator looking for `/favicon.ico` instead of my subfolder url that the rest of puppetboard looks for.

Small fix, but reduces a little bit of noise for me. 😅