### PR TITLE
Adding OpenShift Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,49 @@ We also provide the Dockerfile, so you can build the image yourself:
 docker build -t puppetboard .
 ```
 
+### Using Red Hat OpenShift
+
+The included OpenShift template file helps in the creation of the Puppetboard web interface by adopting a source-to-image methodology.
+
+You can run the app on your OpenShift environment with these commands:
+
+```bash
+# Import the template into OpenShift
+oc create -f puppetboard-s2i-template.yaml 
+
+# Create the Puppetboard application and supporting Pods.
+oc new-app -p PUPPETDB_HOST=puppetdb.fqdn.com \
+           --template=puppetboard-template
+```
+
+This will build a puppetboard application that queries a PuppetDB database at puppetdb.fqdn.com.
+
+Optionally you can set other environment variables to fit your needs:
+
+```bash
+oc new-app -p PUPPETDB_HOST=puppetdb.fqdn.com \
+           -p PUPPETDB_PORT=3456 \
+           -p PUPPETBOARD_SOURCE_REPOSITORY_REF="v5.4.0" \
+           -p PUPPETBOARD_SERVICE_NAME=prod_puppetboard \
+           --template=puppetboard-template
+```
+
+This will build Puppetboard version v5.4.0 that queries the PuppetDB server on TCP/3456.
+
+The following is a list of OpenShift parameters that you can pass to the ``oc`` command to customize the application:
+
+- `PUPPETBOARD_SERVICE_NAME`: This is the name that will be used for application.  Deployment Configs, Build Configs 
+    Services, Routes and Pods will use this value for their names as well.  You can instantiate multiple applications
+    by using different names in ``oc new-app``.  Defaults to 'puppetboard'.
+- `PUPPETDB_HOST`: This is the name of the PuppetDB host that Puppetboard will query for its reports.  Defaults to 'puppetdb'.
+- `PUPPETDB_PORT`: This is tcp port on the `PUPPETDB_HOST` for queries.  Defaults to '8080'.
+- `PUPPETBOARD_SECRET_KEY`: Identical to `SECRET_KEY` (below).  Defaults to 'Secr3t_K3y'.
+- `PUPPETBOARD_PORT`: The TCP port on which the Puppetboard docker image presents the web interface.  This is not the
+    user-facing web interface.  Rather, it's the port that the OpenShift route forwards **to**.  
+- `SERVICE_PORT`: The TCP port on which the Puppetboard service offers its user-facing web interface on OpenShift.  Defaults to '80'.
+- `PUPPETBOARD_SOURCE_REPOSITORY_URL`: The URL to the Puppetboard repository.  Defaults to 'https://github.com/voxpupuli/puppetboard.git'.
+- `PUPPETBOARD_SOURCE_REPOSITORY_REF`: The branch/tag/ref for Puppetboard.  Defaults to 'master'.
+
 ### From a package
 
 Actively maintained packages:

--- a/puppetboard-s2i-template.yaml
+++ b/puppetboard-s2i-template.yaml
@@ -1,0 +1,182 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: puppetboard-template
+objects:
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    annotations:
+    labels:
+      app: ${PUPPETBOARD_SERVICE_NAME}
+    name: ${PUPPETBOARD_SERVICE_NAME}
+  spec:
+    lookupPolicy:
+      local: false
+- kind: "BuildConfig"
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: "${PUPPETBOARD_SERVICE_NAME}" 
+    generation: 2
+    labels:
+      app: ${PUPPETBOARD_SERVICE_NAME}
+  spec:
+    failedBuildsHistoryLimit: 5
+    nodeSelector: null
+    runPolicy: "Serial" 
+    triggers: 
+      - type: "GitHub"
+        github:
+          secret: "secret101"
+      - type: "Generic"
+        generic:
+          secret: "secret101"
+      - type: "ConfigChange"
+      - type: "ImageChange"
+        imageChange: {}
+    source: 
+      git:
+        uri: ${PUPPETBOARD_SOURCE_REPOSITORY_URL}
+        ref: ${PUPPETBOARD_SOURCE_REPOSITORY_REF}
+      type: Git
+    strategy: 
+      dockerStragegy:
+        from:
+          kind: "ImageStreamTag"
+          name: python:3.12-alpine
+      type: Docker
+    output: 
+      to:
+        kind: "ImageStreamTag"
+        name: "${PUPPETBOARD_SERVICE_NAME}:latest"
+    successfulBuildsHistoryLimit: 5
+- kind: "DeploymentConfig"
+  apiVersion: "v1"
+  metadata:
+    name: "${PUPPETBOARD_SERVICE_NAME}"
+    labels:
+      app: ${PUPPETBOARD_SERVICE_NAME}
+  spec:
+    template: 
+      metadata:
+        labels:
+          name: "${PUPPETBOARD_SERVICE_NAME}"
+          app: ${PUPPETBOARD_SERVICE_NAME}
+      spec:
+        containers:
+          - name: "${PUPPETBOARD_SERVICE_NAME}"
+            imagePullPolicy: Always
+            ports:
+              - containerPort: ${{PUPPETDB_PORT}}
+                protocol: "TCP"
+            env:
+              - name: PUPPETDB_HOST
+                value: ${PUPPETDB_HOST}
+              - name: PUPPETDB_PORT
+                value: "${PUPPETDB_PORT}"
+              - name: SECRET_KEY
+                value: ${PUPPETBOARD_SECRET_KEY}
+              - name: PUPPETBOARD_PORT
+                value: "${PUPPETBOARD_PORT}"
+        restartPolicy: Always
+    replicas: 3 
+    triggers:
+      - type: "ConfigChange" 
+      - type: "ImageChange" 
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - "${PUPPETBOARD_SERVICE_NAME}"
+          from:
+            kind: "ImageStreamTag"
+            name: "${PUPPETBOARD_SERVICE_NAME}:latest"
+    strategy: 
+      type: "Rolling"
+    paused: false 
+    revisionHistoryLimit: 2 
+    minReadySeconds: 0 
+- kind: Service
+  apiVersion: v1
+  metadata:
+    annotations:
+    name: ${PUPPETBOARD_SERVICE_NAME}
+    labels:
+      app: ${PUPPETBOARD_SERVICE_NAME}
+  spec:
+    ports:
+    # TODO:  This is kinda confusing.
+    - name: "${SERVICE_PORT}-tcp"
+      protocol: TCP
+      port: ${{SERVICE_PORT}}
+      targetPort: ${{PUPPETBOARD_PORT}}
+    selector:
+      app: ${PUPPETBOARD_SERVICE_NAME}
+    type: ClusterIP
+    sessionAffinity: None
+- kind: Route
+  apiVersion: route.openshift.io/v1
+  metadata:
+    name: ${PUPPETBOARD_SERVICE_NAME}
+    labels:
+      app: ${PUPPETBOARD_SERVICE_NAME}
+    annotations:
+  spec:
+    to:
+      kind: Service
+      name: ${PUPPETBOARD_SERVICE_NAME}
+      weight: 100
+    port:
+      targetPort: "${SERVICE_PORT}-tcp"
+    tls:
+      termination: edge
+  wildcardPolicy: None  
+
+parameters:
+- description: The name of the OpenShift Service exposed for Puppetboard.
+  displayName: Puppetboard Service Name
+  name: PUPPETBOARD_SERVICE_NAME
+  required: true
+  value: puppetboard 
+# These values are passed to the Docker container.  They are not
+# used in the building of the OpenShift app.  They are passed via environment
+# variables in the DeploymentConfig section above.
+- description: Remote server where PuppetDB is running.
+  displayName: PuppetDB Remote Server
+  from: '[a-zA-Z0-9]'
+  name: PUPPETDB_HOST
+  required: true
+  value: puppetdb
+- description: The remote port on the PuppetDB server where Postgresql is listening.
+  displayName: PuppetDB port 
+  name: PUPPETDB_PORT
+  required: true
+  type: integer
+  value: "8080"
+- description: Secret Key for the Puppetboard.
+  displayName: Puppetboard Secret Key
+  from: '[a-zA-Z0-9]'
+  name: PUPPETBOARD_SECRET_KEY
+  required: true
+  value: Secr3t_K3y
+- description: The port on which the Puppetboard server offers up the web interface.
+  displayName: Puppetboard Port
+  name: PUPPETBOARD_PORT
+  required: true
+  value: "1024"
+  type: integer
+- description: The port on which OpenShift offers the Puppetboard service.
+  displayName: OpenShift Service Port
+  name: SERVICE_PORT
+  required: true
+  value: "80"
+  type: integer
+- description: The URL of the repository with the Puppetboard application code.
+  displayName: Puppetboard Repository URL
+  name: PUPPETBOARD_SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/voxpupuli/puppetboard.git
+- description: The branch name, tag or other ref of the PUPPETBOARD_SOURCE_REPOSITORY_URL.
+  displayName: Puppetboard Repository Ref
+  name: PUPPETBOARD_SOURCE_REPOSITORY_REF
+  required: true
+  value: "master"


### PR DESCRIPTION
I have created an OpenShift template that allows very easy creation and configuration of the Puppetboard Docker image.

Neither the location nor the name of the template file is of any consequence (to me) so I'm looking to the community for guidance.

I have updated the README.me and it's a giant work in progress.  

I would appreciate comments and changes as needed.

I realize that everything is still very rough but I wanted to get the Voxpupuli community engaged.