### PR TITLE
Align structured facts with tops of cells

### DIFF
--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -275,3 +275,7 @@ td.code {
 .dataTables_length > label {
   margin-right: 1em;
 }
+
+#facts_table td {
+  vertical-align: top;
+}


### PR DESCRIPTION
Structured facts are potentially very long, so it can be hard to find the keys and values. This puts them at the top of the cells, which might be less visibly pleasing from a design perspective, but is definitely more useful.