### PR TITLE
fix: pypi action missing setuptools

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.12
       - name: Install dependencies
         run: |
-          pip install wheel
+          pip install wheel setuptools
       - name: Build
         run: |
           python setup.py build sdist bdist_wheel


### PR DESCRIPTION
Action "publish 🐍 egg to PyPI" fails with error "ModuleNotFoundError: No module named 'setuptools'", see [here](https://github.com/voxpupuli/puppetboard/actions/runs/12028110016/job/33530525959)

EDIT: this is probably due to [gh-95299](https://github.com/python/cpython/issues/95299), see [Python 3.12 docs](https://docs.python.org/3/whatsnew/3.12.html)