### PR TITLE
Add APPLICATION_ROOT to docker_settings.py

### DIFF
--- a/puppetboard/docker_settings.py
+++ b/puppetboard/docker_settings.py
@@ -45,6 +45,7 @@ def coerce_bool(v, default):
         return False
     return default
 
+APPLICATION_ROOT = os.getenv('PUPPETBOARD_URL_PREFIX','/')
 
 PUPPETDB_HOST = os.getenv('PUPPETDB_HOST', 'puppetdb')
 PUPPETDB_PORT = int(os.getenv('PUPPETDB_PORT', '8080'))


### PR DESCRIPTION
Add APPLICATION_ROOT to docker_settings.py. This way setting PUPPETBOARD_URL_PREFIX works. If APPLICATION_ROOT is not set and PUPPETBOARD_URL_PREFIX is set, every call will result in a 500 error with "IndexError: list index out of range".

This should resolve #1092 