### PR TITLE
Add UNRESPONSIVE_HOURS parameter to OpenShift template.

### DIFF
--- a/puppetboard-s2i-template.yaml
+++ b/puppetboard-s2i-template.yaml
@@ -180,3 +180,9 @@ parameters:
   name: PUPPETBOARD_SOURCE_REPOSITORY_REF
   required: true
   value: "master"
+- description: The amount of hours after which Puppetboard will display the node as unreported if it hasn't checked in.
+  displayName: Puppetboard UNRESPONSIVE_HOURS
+  name: UNRESPONSIVE_HOURS
+  required: true
+  value: "2"
+  type: integer


### PR DESCRIPTION
This allows for the adjustment of "unreported in the last 2 hours".