### PR TITLE
Add Query Presets feature

### DIFF
--- a/QUERY_PRESETS.md
+++ b/QUERY_PRESETS.md
@@ -1,0 +1,221 @@
+# Query Presets Feature
+
+## Overview
+
+The Query Presets feature allows users to save and quickly load frequently-used PuppetDB queries through a YAML configuration file. This eliminates the need to repeatedly type common queries and provides a library of useful query examples for users.
+
+## Configuration
+
+### 1. Enable Query Presets
+
+In your Puppetboard configuration file (e.g., `local_settings.py` or `docker_settings.py`), set the path to your presets file:
+
+```python
+QUERY_PRESETS_FILE = '/etc/puppetboard/query_presets.yaml'
+```
+
+Set to `None` to disable presets:
+
+```python
+QUERY_PRESETS_FILE = None  # Presets disabled
+```
+
+### 2. Create a Presets File
+
+Create a YAML file with your preset queries. See `query_presets.yaml.example` for a complete example with many preset queries.
+
+**Basic structure:**
+
+```yaml
+- name: "All Nodes"
+  description: "List all nodes with basic info"
+  query: 'nodes[certname, catalog_timestamp] {}'
+  endpoint: pql
+  raw_json: false
+
+- name: "Failed Nodes"
+  description: "Nodes with failed runs"
+  query: 'nodes[certname] { latest_report_status = "failed" }'
+  endpoint: pql
+  raw_json: false
+```
+
+## Preset Fields
+
+Each preset supports the following fields:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `name` | **Yes** | - | Display name shown in the dropdown |
+| `query` | **Yes** | - | The PuppetDB query string |
+| `description` | No | `""` | Brief description (shown below dropdown) |
+| `endpoint` | No | `"pql"` | PuppetDB API endpoint to query |
+| `raw_json` | No | `false` | Display results as JSON instead of table |
+
+### Available Endpoints
+
+- `pql` - PQL queries (default, recommended)
+- `nodes` - Nodes endpoint (AST queries)
+- `resources` - Resources endpoint (AST queries)
+- `facts` - Facts endpoint (AST queries)
+- `factsets` - Fact Sets endpoint (AST queries)
+- `fact-paths` - Fact Paths endpoint (AST queries)
+- `fact-contents` - Fact Contents endpoint (AST queries)
+- `fact-names` - Fact Names endpoint
+- `reports` - Reports endpoint (AST queries)
+- `events` - Events endpoint (AST queries)
+- `catalogs` - Catalogs endpoint (AST queries)
+- `edges` - Edges endpoint (AST queries)
+- `environments` - Environments endpoint
+
+**Note:** Non-PQL endpoints expect AST (Abstract Syntax Tree) queries. Puppetboard will automatically wrap them with `[]` brackets if needed.
+
+## Usage
+
+1. Navigate to the **Query** tab in Puppetboard
+2. If presets are configured, you'll see a "Load Preset Query" dropdown at the top of the form
+3. Select a preset from the dropdown
+4. The form fields will auto-populate with:
+   - Query text
+   - API endpoint
+   - Raw JSON checkbox state
+5. If the preset has a description, it will appear below the dropdown
+6. Click "Submit" to execute the query
+
+## Example Preset Queries
+
+### PQL Queries (Recommended)
+
+```yaml
+# Simple node query
+- name: "All Nodes"
+  query: 'nodes[certname, catalog_timestamp, facts_timestamp] {}'
+  endpoint: pql
+
+# Filtered query
+- name: "Ubuntu Nodes"
+  query: 'inventory[certname, facts.os.release.full] { facts.os.name = "Ubuntu" }'
+  endpoint: pql
+
+# Aggregation query
+- name: "Node Count by Environment"
+  query: |
+    nodes[count(), catalog_environment] {
+      group by catalog_environment
+    }
+  endpoint: pql
+
+# Filtered query with condition
+- name: "Failed Events"
+  query: |
+    events[certname, resource_type, message, timestamp] {
+      status = "failure"
+    }
+  endpoint: pql
+```
+
+### AST Queries
+
+```yaml
+# AST query for nodes endpoint
+- name: "AST - Ubuntu Nodes"
+  description: "Find Ubuntu nodes using AST query"
+  query: '"=", "facts.os.name", "Ubuntu"'
+  endpoint: nodes
+  raw_json: false
+```
+
+### Endpoint-Specific Queries
+
+```yaml
+# Get all fact names as JSON
+- name: "All Fact Names"
+  description: "List all available fact names"
+  query: ""
+  endpoint: fact-names
+  raw_json: true
+
+# Get all environments
+- name: "All Environments"
+  description: "List all Puppet environments"
+  query: ""
+  endpoint: environments
+  raw_json: true
+```
+
+## Tips
+
+1. **Use Multi-line Queries**: For complex queries, use YAML's multi-line string syntax:
+   ```yaml
+   query: |
+     nodes[certname, facts.os.name, facts.os.release.full] {
+       facts.os.name ~ "(?i)ubuntu"
+       order by catalog_timestamp desc
+     }
+   ```
+
+2. **Organize by Category**: Group related queries together in your YAML file with comments:
+   ```yaml
+   # === Node Queries ===
+   - name: "All Nodes"
+     ...
+
+   # === Fact Queries ===
+   - name: "OS Distribution"
+     ...
+   ```
+
+3. **Include Examples**: Provide example presets that demonstrate different query patterns for your users.
+
+4. **Use Raw JSON for APIs**: When querying endpoint-specific data (like fact-names, environments), use `raw_json: true` to see the actual API response.
+
+5. **Test Your Queries**: Always test queries in the Query tab before adding them to the presets file.
+
+## Troubleshooting
+
+### Presets Not Showing Up
+
+1. **Check Configuration**: Verify `QUERY_PRESETS_FILE` is set correctly in your settings
+2. **Check File Path**: Ensure the file path is absolute and accessible to Puppetboard
+3. **Check File Permissions**: Ensure Puppetboard process can read the file
+4. **Check Logs**: Look for warnings in Puppetboard logs about YAML parsing errors
+5. **Validate YAML**: Use a YAML validator to check syntax
+
+### Preset Validation Errors
+
+Presets are validated on load. Check logs for warnings about:
+- Missing required fields (`name` or `query`)
+- Invalid YAML syntax
+- Incorrect data types
+
+Invalid presets are skipped gracefully - the app will continue with valid presets only.
+
+### Query Execution Fails
+
+If a preset query fails when executed:
+1. Check that the endpoint is in `ENABLED_QUERY_ENDPOINTS` config
+2. Verify the query syntax matches the selected endpoint
+3. For AST queries, ensure proper syntax (PQL is recommended for most use cases)
+
+## Security Considerations
+
+1. **File Access**: Only Puppetboard process needs read access to the presets file
+2. **Query Safety**: Presets don't bypass PuppetDB query restrictions - all normal security applies
+3. **User Modifications**: Users can modify loaded presets before submission - treat presets as templates
+4. **Endpoint Restrictions**: Respect `ENABLED_QUERY_ENDPOINTS` configuration to limit available endpoints
+
+## Migration from Manual Queries
+
+To convert frequently-used manual queries to presets:
+
+1. Execute the query normally in the Query tab
+2. Once it works, copy the query text
+3. Add it to your presets YAML file with a descriptive name
+4. Reload Puppetboard to see the new preset
+
+## See Also
+
+- [PuppetDB PQL Query Tutorial](https://puppet.com/docs/puppetdb/latest/api/query/tutorial-pql.html)
+- [PuppetDB AST Query Tutorial](https://puppet.com/docs/puppetdb/latest/api/query/tutorial.html)
+- [PuppetDB API Endpoints](https://puppet.com/docs/puppetdb/latest/api/query/v4/overview.html)
+- `query_presets.yaml.example` - Example presets file with many query examples

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -14,6 +14,8 @@ UNRESPONSIVE_HOURS = 2
 ENABLE_QUERY = True
 # Uncomment to restrict the enabled PuppetDB endpoints in the query page.
 # ENABLED_QUERY_ENDPOINTS = ['facts', 'nodes']
+# Path to YAML file containing preset queries (None to disable)
+QUERY_PRESETS_FILE = None  # Example: '/etc/puppetboard/query_presets.yaml'
 LOCALISE_TIMESTAMP = True
 LOGLEVEL = 'info'
 NORMAL_TABLE_COUNT = 100

--- a/puppetboard/templates/query.html
+++ b/puppetboard/templates/query.html
@@ -36,6 +36,26 @@
 <div class="ui form">
   <form method="POST" id="form" action="{{ url_for('query', env=current_env) }}">
     {{ form.csrf_token }}
+
+    {# Preset Queries Listbox #}
+    {% if query_presets and query_presets|length > 0 %}
+    <div class="field">
+      <label>Load Preset Query</label>
+      <select id="preset-selector" size="8" style="width: 100%; font-family: monospace;">
+        {% for preset in query_presets %}
+        <option value="{{ loop.index0 }}"
+                data-query="{{ preset.query }}"
+                data-endpoint="{{ preset.endpoint }}"
+                data-raw-json="{{ preset.raw_json|lower }}"
+                data-description="{{ preset.description }}">
+          {{ preset.name }}
+        </option>
+        {% endfor %}
+      </select>
+      <small id="preset-description" style="display: block; color: #666; margin-top: 5px; min-height: 1.2em;"></small>
+    </div>
+    {% endif %}
+
     <div class="field {% if form.query.errors %} error {% endif %}">
       {{ form.query(autofocus="autofocus", rows=5, placeholder="nodes { certname = \"hostname\" }") }}
     </div>
@@ -52,6 +72,52 @@
     </div>
   </form>
 </div>
+
+<script type="text/javascript">
+  $(document).ready(function() {
+    // Function to load preset data into form
+    function loadPreset(selectedOption) {
+      const query = selectedOption.data('query');
+      const endpoint = selectedOption.data('endpoint');
+      const rawJson = selectedOption.data('raw-json');
+      const description = selectedOption.data('description');
+
+      if (query) {
+        // Populate form fields
+        $('#query').val(query);
+        $('#endpoints').val(endpoint);
+        $('#rawjson').prop('checked', rawJson === 'true');
+
+        // Save selected preset index to localStorage
+        localStorage.setItem('selectedPresetIndex', selectedOption.val());
+
+        // Show description
+        if (description) {
+          $('#preset-description').text(description);
+        } else {
+          $('#preset-description').text('');
+        }
+      }
+    }
+
+    // Restore previously selected preset from localStorage
+    const savedPresetIndex = localStorage.getItem('selectedPresetIndex');
+    if (savedPresetIndex !== null) {
+      const presetSelector = $('#preset-selector');
+      presetSelector.val(savedPresetIndex);
+      const selectedOption = presetSelector.find('option:selected');
+      if (selectedOption.length > 0 && selectedOption.data('query')) {
+        loadPreset(selectedOption);
+      }
+    }
+
+    // Handle preset selection change
+    $('#preset-selector').on('change', function() {
+      const selectedOption = $(this).find('option:selected');
+      loadPreset(selectedOption);
+    });
+  });
+</script>
 
 {% if result or zero_results or error_text %}
 

--- a/puppetboard/views/query.py
+++ b/puppetboard/views/query.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import yaml
 
 from flask import (
     render_template, abort, session
@@ -15,6 +17,62 @@ puppetdb = get_puppetdb()
 
 logging.basicConfig(level=app.config['LOGLEVEL'].upper())
 log = logging.getLogger(__name__)
+
+
+def load_query_presets():
+    """Load query presets from YAML file specified in config.
+
+    Returns a list of preset dicts with keys: name, description, query, endpoint, raw_json
+    Returns empty list if file doesn't exist, is disabled, or has parsing errors.
+    """
+    presets_file = app.config.get('QUERY_PRESETS_FILE')
+
+    if not presets_file:
+        return []
+
+    if not os.path.exists(presets_file):
+        log.warning('Query presets file not found: %s', presets_file)
+        return []
+
+    try:
+        with open(presets_file, 'r') as f:
+            presets = yaml.safe_load(f)
+
+        if not isinstance(presets, list):
+            log.error('Query presets file must contain a list of presets')
+            return []
+
+        # Validate each preset has required fields
+        validated_presets = []
+        for idx, preset in enumerate(presets):
+            if not isinstance(preset, dict):
+                log.warning('Preset at index %d is not a dict, skipping', idx)
+                continue
+
+            if 'name' not in preset or 'query' not in preset:
+                log.warning('Preset at index %d missing required fields (name, query), skipping', idx)
+                continue
+
+            # Provide defaults for optional fields
+            validated_preset = {
+                'name': preset['name'],
+                'description': preset.get('description', ''),
+                'query': preset['query'],
+                'endpoint': preset.get('endpoint', 'pql'),
+                'raw_json': preset.get('raw_json', False)
+            }
+
+            validated_presets.append(validated_preset)
+
+        log.info('Loaded %d query presets from %s', len(validated_presets), presets_file)
+        return validated_presets
+
+    except yaml.YAMLError as e:
+        log.error('Error parsing query presets YAML file: %s', e)
+        return []
+    except Exception as e:
+        log.error('Error loading query presets file: %s', e)
+        return []
 
 
 @app.route('/query', methods=('GET', 'POST'), defaults={'env': app.config['DEFAULT_ENVIRONMENT']})
@@ -34,6 +92,9 @@ def query(env):
     envs = environments()
     if env != app.config['DEFAULT_ENVIRONMENT']:
         check_env(env, envs)
+
+    # Load query presets from YAML file
+    query_presets = load_query_presets()
 
     form = QueryForm(meta={
         'csrf_secret': app.config['SECRET_KEY'],
@@ -69,7 +130,8 @@ def query(env):
                                        result=result,
                                        columns=None,
                                        envs=envs,
-                                       current_env=env)
+                                       current_env=env,
+                                       query_presets=query_presets)
             else:
                 # for table view separate the columns and the rows
                 rows = []
@@ -86,7 +148,8 @@ def query(env):
                                        result=rows,
                                        columns=columns,
                                        envs=envs,
-                                       current_env=env)
+                                       current_env=env,
+                                       query_presets=query_presets)
 
         except HTTPError as e:
             error_text = e.response.text
@@ -94,9 +157,11 @@ def query(env):
                                    form=form,
                                    error_text=error_text,
                                    envs=envs,
-                                   current_env=env)
+                                   current_env=env,
+                                   query_presets=query_presets)
 
     return render_template('query.html',
                            form=form,
                            envs=envs,
-                           current_env=env)
+                           current_env=env,
+                           query_presets=query_presets)

--- a/query_presets.yaml.example
+++ b/query_presets.yaml.example
@@ -1,0 +1,175 @@
+# Example Query Presets File for Puppetboard
+#
+# This file contains preset queries that users can quickly load in the Query tab.
+# Each preset should have the following fields:
+#   - name: (required) Display name shown in the dropdown
+#   - description: (optional) Brief description of what the query does
+#   - query: (required) The actual query string
+#   - endpoint: (optional) PuppetDB API endpoint (default: 'pql')
+#              Options: pql, nodes, resources, facts, factsets, fact-paths,
+#                       fact-contents, reports, events, catalogs, edges, environments
+#   - raw_json: (optional) Boolean to show raw JSON instead of table (default: false)
+#
+# To use this file:
+# 1. Copy this file to your desired location (e.g., /etc/puppetboard/query_presets.yaml)
+# 2. Edit your Puppetboard configuration to set:
+#    QUERY_PRESETS_FILE = '/etc/puppetboard/query_presets.yaml'
+# 3. Restart Puppetboard
+
+# Example presets:
+
+- name: "All Nodes"
+  description: "List all nodes with their certname, catalog timestamp, and facts timestamp"
+  query: 'nodes[certname, catalog_timestamp, facts_timestamp] {}'
+  endpoint: pql
+  raw_json: false
+
+- name: "Failed Nodes"
+  description: "Find nodes with failed runs in the last report"
+  query: 'nodes[certname, latest_report_status] { latest_report_status = "failed" }'
+  endpoint: pql
+  raw_json: false
+
+- name: "Nodes by OS"
+  description: "Group nodes by operating system"
+  query: |
+    inventory[certname, facts.os.name, facts.os.release.full] {
+      facts.os.name ~ ".*"
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Failed Events"
+  description: "Show failed events from recent runs"
+  query: |
+    events[certname, resource_type, resource_title, status, timestamp] {
+      status = "failure"
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Package Resources"
+  description: "Find all package resources across all nodes"
+  query: |
+    resources[certname, title, parameters] {
+      type = "Package"
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Nodes Without Recent Reports"
+  description: "Find nodes ordered by report timestamp (oldest first)"
+  query: |
+    nodes[certname, report_timestamp, catalog_timestamp] {
+      order by report_timestamp
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Node Count by Environment"
+  description: "Count nodes grouped by environment"
+  query: |
+    nodes[count(), catalog_environment] {
+      group by catalog_environment
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Custom Fact Query"
+  description: "Query specific custom facts (example: role and datacenter)"
+  query: |
+    inventory[certname, facts.role, facts.datacenter] {
+      facts.role is not null
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Resource Changes"
+  description: "Find resources that changed in the last run"
+  query: |
+    events[certname, resource_type, resource_title, property, old_value, new_value] {
+      status = "success" and old_value is not null and new_value is not null
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "File Resources"
+  description: "Find all File resources on nodes"
+  query: |
+    resources[certname, title, parameters] {
+      type = "File"
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Service Resources"
+  description: "Find all Service resources on nodes"
+  query: |
+    resources[certname, title, parameters] {
+      type = "Service"
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Nodes with Specific Class"
+  description: "Find all nodes with a specific Puppet class (replace 'Apache' with your class)"
+  query: |
+    nodes[certname] {
+      resources {
+        type = "Class" and title = "Apache"
+      }
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Inactive Nodes"
+  description: "Find nodes marked as inactive in PuppetDB"
+  query: 'nodes[certname, deactivated] { node_state = "inactive" }'
+  endpoint: pql
+  raw_json: false
+
+- name: "Windows Nodes"
+  description: "Find all Windows nodes"
+  query: 'inventory[certname, facts.os.release.full] { facts.os.name = "windows" }'
+  endpoint: pql
+  raw_json: false
+
+- name: "Corrective Changes"
+  description: "Find nodes that had corrective changes (drift from desired state)"
+  query: |
+    events[certname, resource_type, resource_title] {
+      corrective_change = true
+      group by certname, resource_type, resource_title
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Resource Count by Type"
+  description: "Count resources grouped by type"
+  query: |
+    resources[count(), type] {
+      group by type
+      order by count() desc
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Unique Domains"
+  description: "Get all unique domain fact values across nodes"
+  query: |
+    facts[value] {
+      name = "domain"
+      group by value
+    }
+  endpoint: pql
+  raw_json: false
+
+- name: "Nodes by OS and Version"
+  description: "Group nodes by OS name and major version"
+  query: |
+    inventory[certname, facts.os.name, facts.os.release.major] {
+      facts.os.name is not null
+      order by certname
+    }
+  endpoint: pql
+  raw_json: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ MarkupSafe==3.0.3
 packaging==26.0
 pyparsing==3.3.2
 pypuppetdb==3.2.0
+PyYAML==6.0.2
 requests==2.32.5
 typing_extensions==4.15.0
 urllib3==2.6.3

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -72,5 +72,6 @@ def input_data(request):
 @pytest.fixture
 def client():
     app.app.config['TESTING'] = True
+    app.app.config['SECRET_KEY'] = 'test_secret_key_for_testing'
     client = app.app.test_client()
     return client

--- a/test/views/test_facts.py
+++ b/test/views/test_facts.py
@@ -555,10 +555,10 @@ def test_fact_children_ajax_skips_keys_with_dots(client, mocker,
     result_json = json.loads(rv.data.decode('utf-8'))
     assert 'children' in result_json
 
-    # Should only include ValidServiceName, not G1.ActivOneApiDaemon (has dot)
+    # Should only include ValidServiceName, not myco.SomeService (has dot)
     children_names = [c['name'] for c in result_json['children']]
     assert 'myco_services.ValidServiceName' in children_names
-    assert 'myco_services.G1.ActivOneApiDaemon' not in children_names
+    assert 'myco_services.myco.SomeService' not in children_names
 
 
 def test_fact_children_ajax_skips_keys_with_slashes(client, mocker,

--- a/test/views/test_query.py
+++ b/test/views/test_query.py
@@ -1,3 +1,6 @@
+import tempfile
+import os
+
 from bs4 import BeautifulSoup
 from requests.exceptions import HTTPError
 
@@ -154,3 +157,284 @@ def test_query__error_response(client, mocker,
     vals = soup.find_all('pre', {"id": "invalid_query"})
     assert len(vals) == 1
     assert error_message in vals[0].string
+
+
+def test_query_presets_loaded(client, mocker,
+                               mock_puppetdb_environments,
+                               mock_puppetdb_default_nodes):
+    """Test that query presets are loaded and displayed when configured"""
+    # Create a temporary YAML file with test presets
+    preset_content = """
+- name: "Test Query 1"
+  description: "Test description 1"
+  query: "nodes { certname ~ '.*' }"
+  endpoint: pql
+  raw_json: false
+
+- name: "Test Query 2"
+  description: "Test description 2"
+  query: "facts { name = 'os' }"
+  endpoint: facts
+  raw_json: true
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(preset_content)
+        preset_file = f.name
+
+    try:
+        # Configure app to use the preset file
+        app.app.config['QUERY_PRESETS_FILE'] = preset_file
+
+        rv = client.get('/query')
+        assert rv.status_code == 200
+
+        soup = BeautifulSoup(rv.data, 'html.parser')
+
+        # Check that preset dropdown exists
+        preset_selector = soup.find('select', {'id': 'preset-selector'})
+        assert preset_selector is not None
+
+        # Check that both presets are in the dropdown
+        options = preset_selector.find_all('option')
+        assert len(options) == 2  # 2 presets
+
+        # Check preset 1
+        option1 = soup.find('option', {'data-query': "nodes { certname ~ '.*' }"})
+        assert option1 is not None
+        assert 'Test Query 1' in option1.text
+        assert option1.get('data-endpoint') == 'pql'
+        assert option1.get('data-raw-json') == 'false'
+        assert option1.get('data-description') == 'Test description 1'
+
+        # Check preset 2
+        option2 = soup.find('option', {'data-query': "facts { name = 'os' }"})
+        assert option2 is not None
+        assert 'Test Query 2' in option2.text
+        assert option2.get('data-endpoint') == 'facts'
+        assert option2.get('data-raw-json') == 'true'
+
+    finally:
+        # Clean up temp file
+        if os.path.exists(preset_file):
+            os.unlink(preset_file)
+        # Reset config
+        app.app.config['QUERY_PRESETS_FILE'] = None
+
+
+def test_query_no_presets_when_disabled(client, mocker,
+                                         mock_puppetdb_environments,
+                                         mock_puppetdb_default_nodes):
+    """Test that preset dropdown is not shown when QUERY_PRESETS_FILE is None"""
+    app.app.config['QUERY_PRESETS_FILE'] = None
+
+    rv = client.get('/query')
+    assert rv.status_code == 200
+
+    soup = BeautifulSoup(rv.data, 'html.parser')
+
+    # Check that preset dropdown does NOT exist
+    preset_selector = soup.find('select', {'id': 'preset-selector'})
+    assert preset_selector is None
+
+
+def test_query_presets_invalid_yaml(client, mocker,
+                                     mock_puppetdb_environments,
+                                     mock_puppetdb_default_nodes):
+    """Test that invalid YAML in presets file doesn't crash the app"""
+    # Create a temporary YAML file with invalid content
+    preset_content = """
+- name: "Test Query"
+  invalid yaml here
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(preset_content)
+        preset_file = f.name
+
+    try:
+        app.app.config['QUERY_PRESETS_FILE'] = preset_file
+
+        rv = client.get('/query')
+        assert rv.status_code == 200
+
+        soup = BeautifulSoup(rv.data, 'html.parser')
+
+        # App should handle error gracefully and not show presets
+        preset_selector = soup.find('select', {'id': 'preset-selector'})
+        # Might be None or have no options
+        if preset_selector:
+            options = preset_selector.find_all('option')
+            assert len(options) <= 1  # Only default option or none
+
+    finally:
+        if os.path.exists(preset_file):
+            os.unlink(preset_file)
+        app.app.config['QUERY_PRESETS_FILE'] = None
+
+
+def test_query_presets_missing_required_fields(client, mocker,
+                                                mock_puppetdb_environments,
+                                                mock_puppetdb_default_nodes):
+    """Test that presets missing required fields are skipped"""
+    preset_content = """
+- name: "Valid Query"
+  query: "nodes {}"
+
+- description: "Missing name field"
+  query: "nodes {}"
+
+- name: "Missing query field"
+  endpoint: pql
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(preset_content)
+        preset_file = f.name
+
+    try:
+        app.app.config['QUERY_PRESETS_FILE'] = preset_file
+
+        rv = client.get('/query')
+        assert rv.status_code == 200
+
+        soup = BeautifulSoup(rv.data, 'html.parser')
+        preset_selector = soup.find('select', {'id': 'preset-selector'})
+
+        if preset_selector:
+            options = preset_selector.find_all('option')
+            # Should have 1 valid preset (the other 2 should be skipped)
+            assert len(options) == 1
+            assert 'Valid Query' in str(options[0])
+
+    finally:
+        if os.path.exists(preset_file):
+            os.unlink(preset_file)
+        app.app.config['QUERY_PRESETS_FILE'] = None
+
+
+def test_query_presets_file_not_found(client, mocker,
+                                       mock_puppetdb_environments,
+                                       mock_puppetdb_default_nodes):
+    """Test that a non-existent presets file is handled gracefully"""
+    app.app.config['QUERY_PRESETS_FILE'] = '/nonexistent/path/presets.yaml'
+
+    rv = client.get('/query')
+    assert rv.status_code == 200
+
+    soup = BeautifulSoup(rv.data, 'html.parser')
+
+    # Preset selector should not be shown when file doesn't exist
+    preset_selector = soup.find('select', {'id': 'preset-selector'})
+    assert preset_selector is None
+
+    # Reset config
+    app.app.config['QUERY_PRESETS_FILE'] = None
+
+
+def test_query_presets_not_a_list(client, mocker,
+                                   mock_puppetdb_environments,
+                                   mock_puppetdb_default_nodes):
+    """Test that presets file containing non-list data is handled gracefully"""
+    # Create a YAML file with a dict instead of a list
+    preset_content = """
+name: "Single Query"
+query: "nodes {}"
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(preset_content)
+        preset_file = f.name
+
+    try:
+        app.app.config['QUERY_PRESETS_FILE'] = preset_file
+
+        rv = client.get('/query')
+        assert rv.status_code == 200
+
+        soup = BeautifulSoup(rv.data, 'html.parser')
+
+        # Preset selector should not be shown when file format is invalid
+        preset_selector = soup.find('select', {'id': 'preset-selector'})
+        assert preset_selector is None
+
+    finally:
+        if os.path.exists(preset_file):
+            os.unlink(preset_file)
+        app.app.config['QUERY_PRESETS_FILE'] = None
+
+
+def test_query_presets_non_dict_entry(client, mocker,
+                                       mock_puppetdb_environments,
+                                       mock_puppetdb_default_nodes):
+    """Test that non-dict entries in presets list are skipped"""
+    preset_content = """
+- name: "Valid Query"
+  query: "nodes {}"
+
+- "just a string"
+
+- 12345
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(preset_content)
+        preset_file = f.name
+
+    try:
+        app.app.config['QUERY_PRESETS_FILE'] = preset_file
+
+        rv = client.get('/query')
+        assert rv.status_code == 200
+
+        soup = BeautifulSoup(rv.data, 'html.parser')
+        preset_selector = soup.find('select', {'id': 'preset-selector'})
+
+        if preset_selector:
+            options = preset_selector.find_all('option')
+            # Should only have 1 valid preset
+            assert len(options) == 1
+            assert 'Valid Query' in str(options[0])
+
+    finally:
+        if os.path.exists(preset_file):
+            os.unlink(preset_file)
+        app.app.config['QUERY_PRESETS_FILE'] = None
+
+
+def test_query_presets_default_values(client, mocker,
+                                       mock_puppetdb_environments,
+                                       mock_puppetdb_default_nodes):
+    """Test that optional fields get correct default values"""
+    # Create preset with only required fields (name and query)
+    preset_content = """
+- name: "Minimal Query"
+  query: "nodes { certname ~ '.*' }"
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(preset_content)
+        preset_file = f.name
+
+    try:
+        app.app.config['QUERY_PRESETS_FILE'] = preset_file
+
+        rv = client.get('/query')
+        assert rv.status_code == 200
+
+        soup = BeautifulSoup(rv.data, 'html.parser')
+        preset_selector = soup.find('select', {'id': 'preset-selector'})
+        assert preset_selector is not None
+
+        option = soup.find('option', {'data-query': "nodes { certname ~ '.*' }"})
+        assert option is not None
+        assert 'Minimal Query' in option.text
+        # Check default values
+        assert option.get('data-endpoint') == 'pql'  # default endpoint
+        assert option.get('data-raw-json') == 'false'  # default raw_json
+        assert option.get('data-description') == ''  # default empty description
+
+    finally:
+        if os.path.exists(preset_file):
+            os.unlink(preset_file)
+        app.app.config['QUERY_PRESETS_FILE'] = None


### PR DESCRIPTION
The Query Presets feature allows users to save and quickly load frequently-used PuppetDB queries through a YAML configuration file. This eliminates the need to repeatedly type common queries and provides a library of useful query examples for users.