### PR TITLE
nodes: add facts timestamp column and place it last

### DIFF
--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -39,6 +39,7 @@
       <th>Certname</th>
       <th>Catalog</th>
       <th>Report</th>
+      <th>Facts</th>
       <th class="collapsing" data-orderable="false"></th>
     </tr>
   </thead>
@@ -63,6 +64,13 @@
       <td data-order="{{ node.report_timestamp | default('', true) }}">
         {% if node.report_timestamp %}
           <a href="{{url_for('report', env=current_env, node_name=node.name, report_id=node.latest_report_hash)}}"  data-localise="{{ config.LOCALISE_TIMESTAMP|lower }}">{{ node.report_timestamp }}</a>
+        {% else %}
+          <i class="large darkblue ban icon"></i>
+        {% endif %}
+      </td>
+      <td data-order="{{ node.facts_timestamp | default('', true) }}">
+        {% if node.facts_timestamp %}
+          <a href="{{url_for('node', env=current_env, node_name=node.name)}}" data-localise="{{ config.LOCALISE_TIMESTAMP|lower }}">{{ node.facts_timestamp }}</a>
         {% else %}
           <i class="large darkblue ban icon"></i>
         {% endif %}

--- a/test/views/test_nodes.py
+++ b/test/views/test_nodes.py
@@ -14,6 +14,18 @@ def test_default_node_view(client, mocker,
         assert len(vals) == 1
         assert 'node-%s' % label in vals[0].attrs['href']
 
+    headers = [header.get_text(strip=True)
+               for header in soup.select('#main-table thead th')]
+    assert 'Facts' in headers
+    facts_column_index = headers.index('Facts')
+
+    rows = soup.select('#main-table tbody tr')
+    assert len(rows) >= 5
+
+    facts_cells = [row.select('td')[facts_column_index] for row in rows]
+    assert all(cell.get('data-order') for cell in facts_cells)
+    assert all(cell.find('a') is not None for cell in facts_cells)
+
     assert rv.status_code == 200
 
 


### PR DESCRIPTION
I have servers that run puppet infrequenly but should be pushing facts every hour.  I would like to add a Facts column to the nodes screen that shows that last facts timestamp along with the last Catalog and Report timestamps.